### PR TITLE
Close #26 - Add typed version of scala.io.AnsiColor to extras-scala-io

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val extras = (project in file("."))
 
 lazy val extrasScalaIo = subProject("scala-io")
   .settings(
+    libraryDependencies ++= libs.hedgehog,
     libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value)
   )
 

--- a/extras-scala-io/src/main/scala-2/extras/scala/io/Color.scala
+++ b/extras-scala-io/src/main/scala-2/extras/scala/io/Color.scala
@@ -1,0 +1,147 @@
+package extras.scala.io
+
+import scala.io.AnsiColor
+
+sealed trait Color
+
+object Color {
+  case object Black      extends Color
+  case object Red        extends Color
+  case object Green      extends Color
+  case object Yellow     extends Color
+  case object Blue       extends Color
+  case object Magenta    extends Color
+  case object Cyan       extends Color
+  case object White      extends Color
+  case object BlackBg    extends Color
+  case object RedBg      extends Color
+  case object GreenBg    extends Color
+  case object YellowBg   extends Color
+  case object BlueBg     extends Color
+  case object MagentaBg  extends Color
+  case object CyanBg     extends Color
+  case object WhiteBg    extends Color
+  case object Reset      extends Color
+  case object Bold       extends Color
+  case object Underlined extends Color
+  case object Blink      extends Color
+  case object Reversed   extends Color
+  case object Invisible  extends Color
+
+  def black: Color = Black
+
+  def red: Color = Red
+
+  def green: Color = Green
+
+  def yellow: Color = Yellow
+
+  def blue: Color = Blue
+
+  def magenta: Color = Magenta
+
+  def cyan: Color = Cyan
+
+  def white: Color = White
+
+  def blackBg: Color = BlackBg
+
+  def redBg: Color = RedBg
+
+  def greenBg: Color = GreenBg
+
+  def yellowBg: Color = YellowBg
+
+  def blueBg: Color = BlueBg
+
+  def magentaBg: Color = MagentaBg
+
+  def cyanBg: Color = CyanBg
+
+  def whiteBg: Color = WhiteBg
+
+  def reset: Color = Reset
+
+  def bold: Color = Bold
+
+  def underlined: Color = Underlined
+
+  def blink: Color = Blink
+
+  def reversed: Color = Reversed
+
+  def invisible: Color = Invisible
+
+  def render(color: Color): String = color match {
+    case Black =>
+      AnsiColor.BLACK
+
+    case Red =>
+      AnsiColor.RED
+
+    case Green =>
+      AnsiColor.GREEN
+
+    case Yellow =>
+      AnsiColor.YELLOW
+
+    case Blue =>
+      AnsiColor.BLUE
+
+    case Magenta =>
+      AnsiColor.MAGENTA
+
+    case Cyan =>
+      AnsiColor.CYAN
+
+    case White =>
+      AnsiColor.WHITE
+
+    case BlackBg =>
+      AnsiColor.BLACK_B
+
+    case RedBg =>
+      AnsiColor.RED_B
+
+    case GreenBg =>
+      AnsiColor.GREEN_B
+
+    case YellowBg =>
+      AnsiColor.YELLOW_B
+
+    case BlueBg =>
+      AnsiColor.BLUE_B
+
+    case MagentaBg =>
+      AnsiColor.MAGENTA_B
+
+    case CyanBg =>
+      AnsiColor.CYAN_B
+
+    case WhiteBg =>
+      AnsiColor.WHITE_B
+
+    case Reset =>
+      AnsiColor.RESET
+
+    case Bold =>
+      AnsiColor.BOLD
+
+    case Underlined =>
+      AnsiColor.UNDERLINED
+
+    case Blink =>
+      AnsiColor.BLINK
+
+    case Reversed =>
+      AnsiColor.REVERSED
+
+    case Invisible =>
+      AnsiColor.INVISIBLE
+  }
+
+  implicit final class ColorOps(private val color: Color) extends AnyVal {
+    def toAnsi: String = Color.render(color)
+  }
+
+}

--- a/extras-scala-io/src/main/scala-3/extras/scala/io/Color.scala
+++ b/extras-scala-io/src/main/scala-3/extras/scala/io/Color.scala
@@ -1,0 +1,104 @@
+package extras.scala.io
+
+import scala.io.AnsiColor
+
+enum Color derives CanEqual {
+  case Black
+  case Red
+  case Green
+  case Yellow
+  case Blue
+  case Magenta
+  case Cyan
+  case White
+  case BlackBg
+  case RedBg
+  case GreenBg
+  case YellowBg
+  case BlueBg
+  case MagentaBg
+  case CyanBg
+  case WhiteBg
+  case Reset
+  case Bold
+  case Underlined
+  case Blink
+  case Reversed
+  case Invisible
+}
+
+object Color {
+
+  extension (color: Color) {
+    def render: String = color match {
+      case Black =>
+        AnsiColor.BLACK
+
+      case Red =>
+        AnsiColor.RED
+
+      case Green =>
+        AnsiColor.GREEN
+
+      case Yellow =>
+        AnsiColor.YELLOW
+
+      case Blue =>
+        AnsiColor.BLUE
+
+      case Magenta =>
+        AnsiColor.MAGENTA
+
+      case Cyan =>
+        AnsiColor.CYAN
+
+      case White =>
+        AnsiColor.WHITE
+
+      case BlackBg =>
+        AnsiColor.BLACK_B
+
+      case RedBg =>
+        AnsiColor.RED_B
+
+      case GreenBg =>
+        AnsiColor.GREEN_B
+
+      case YellowBg =>
+        AnsiColor.YELLOW_B
+
+      case BlueBg =>
+        AnsiColor.BLUE_B
+
+      case MagentaBg =>
+        AnsiColor.MAGENTA_B
+
+      case CyanBg =>
+        AnsiColor.CYAN_B
+
+      case WhiteBg =>
+        AnsiColor.WHITE_B
+
+      case Reset =>
+        AnsiColor.RESET
+
+      case Bold =>
+        AnsiColor.BOLD
+
+      case Underlined =>
+        AnsiColor.UNDERLINED
+
+      case Blink =>
+        AnsiColor.BLINK
+
+      case Reversed =>
+        AnsiColor.REVERSED
+
+      case Invisible =>
+        AnsiColor.INVISIBLE
+    }
+
+    def toAnsi: String = Color.render(color)
+  }
+
+}

--- a/extras-scala-io/src/test/scala-2/extras/scala/io/ColorSpec.scala
+++ b/extras-scala-io/src/test/scala-2/extras/scala/io/ColorSpec.scala
@@ -1,0 +1,14 @@
+package extras.scala.io
+
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2021-09-19
+  */
+object ColorSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("test all Color.toAnsi", ColorTestUtils.testColorToAnsi)
+  )
+
+}

--- a/extras-scala-io/src/test/scala-3/extras/scala/io/ColorSpec.scala
+++ b/extras-scala-io/src/test/scala-3/extras/scala/io/ColorSpec.scala
@@ -1,0 +1,15 @@
+package extras.scala.io
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2021-09-19
+  */
+object ColorSpec extends Properties {
+  
+  override def tests: List[Test] = List(
+    example("test all Color.toAnsi", ColorTestUtils.testColorToAnsi)
+  )
+
+}

--- a/extras-scala-io/src/test/scala/extras/scala/io/ColorTestUtils.scala
+++ b/extras-scala-io/src/test/scala/extras/scala/io/ColorTestUtils.scala
@@ -1,0 +1,49 @@
+package extras.scala.io
+
+import scala.io.AnsiColor
+
+object ColorTestUtils {
+  def escapeAnsi(s: String): String = "\\u%04x".format(s.head.toInt) + s.tail
+
+
+  import hedgehog.Result
+  def testColorToAnsi: Result = {
+    import hedgehog.Syntax
+    val results = colors.map {
+      case (input, expected) =>
+        val actual = input.toAnsi
+        (actual ==== expected).log(
+          s"${AnsiColor.RESET}${input.toString}.toAnsi should be " +
+            s"${ColorTestUtils.escapeAnsi(expected)} (${expected}O${AnsiColor.RESET}) " +
+            s"but it was ${ColorTestUtils.escapeAnsi(actual)} (${actual}O${AnsiColor.RESET})"
+        )
+    }
+    Result.all(results)
+  }
+
+  private val colors = List(
+    Color.Black      -> AnsiColor.BLACK,
+    Color.Red        -> AnsiColor.RED,
+    Color.Green      -> AnsiColor.GREEN,
+    Color.Yellow     -> AnsiColor.YELLOW,
+    Color.Blue       -> AnsiColor.BLUE,
+    Color.Magenta    -> AnsiColor.MAGENTA,
+    Color.Cyan       -> AnsiColor.CYAN,
+    Color.White      -> AnsiColor.WHITE,
+    Color.BlackBg    -> AnsiColor.BLACK_B,
+    Color.RedBg      -> AnsiColor.RED_B,
+    Color.GreenBg    -> AnsiColor.GREEN_B,
+    Color.YellowBg   -> AnsiColor.YELLOW_B,
+    Color.BlueBg     -> AnsiColor.BLUE_B,
+    Color.MagentaBg  -> AnsiColor.MAGENTA_B,
+    Color.CyanBg     -> AnsiColor.CYAN_B,
+    Color.WhiteBg    -> AnsiColor.WHITE_B,
+    Color.Reset      -> AnsiColor.RESET,
+    Color.Bold       -> AnsiColor.BOLD,
+    Color.Underlined -> AnsiColor.UNDERLINED,
+    Color.Blink      -> AnsiColor.BLINK,
+    Color.Reversed   -> AnsiColor.REVERSED,
+    Color.Invisible  -> AnsiColor.INVISIBLE
+  )
+
+}


### PR DESCRIPTION
Close #26 - Add typed version of `scala.io.AnsiColor` to `extras-scala-io`