### PR TITLE
Close #28 - CanClose[A] type class as an alternative to AutoCloseable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,25 @@ lazy val extras = (project in file("."))
 lazy val extrasScalaIo = subProject("scala-io")
   .settings(
     libraryDependencies ++= libs.hedgehog,
-    libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value)
+    libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
+    Compile / unmanagedSourceDirectories ++= {
+      val sharedSourceDir = baseDirectory.value / "src/main"
+      if (scalaVersion.value.startsWith("2.11") || scalaVersion.value.startsWith("2.12"))
+        List(
+          sharedSourceDir / "scala-2.11_2.12",
+        )
+      else
+        Seq.empty
+    },
+    Test / unmanagedSourceDirectories ++= {
+      val sharedSourceDir = baseDirectory.value / "src/test"
+      if (scalaVersion.value.startsWith("2.11") || scalaVersion.value.startsWith("2.12"))
+        List(
+          sharedSourceDir / "scala-2.11_2.12",
+        )
+      else
+        Seq.empty
+    },
   )
 
 lazy val extrasConcurrent = subProject("concurrent")

--- a/extras-scala-io/src/main/scala-2.11_2.12/extras/scala/io/CanClose.scala
+++ b/extras-scala-io/src/main/scala-2.11_2.12/extras/scala/io/CanClose.scala
@@ -1,0 +1,19 @@
+package extras.scala.io
+
+/** @author Kevin Lee
+  * @since 2021-09-20
+  */
+trait CanClose[-A] {
+
+  def close(a: A): Unit
+}
+
+object CanClose {
+
+  def apply[A: CanClose]: CanClose[A] = implicitly[CanClose[A]]
+
+  implicit final val autoCloseableCanClose: CanClose[AutoCloseable] = new CanClose[AutoCloseable] {
+    override def close(a: AutoCloseable): Unit = a.close()
+  }
+
+}

--- a/extras-scala-io/src/main/scala-2.13/extras/scala/io/CanClose.scala
+++ b/extras-scala-io/src/main/scala-2.13/extras/scala/io/CanClose.scala
@@ -1,0 +1,20 @@
+package extras.scala.io
+
+/**
+ * @author Kevin Lee
+ * @since 2021-09-20
+ */
+trait CanClose[-A] extends scala.util.Using.Releasable[A] {
+
+  override def release(resource: A): Unit = close(resource)
+
+  def close(a: A): Unit
+}
+
+object CanClose {
+
+  def apply[A: CanClose]: CanClose[A] = implicitly[CanClose[A]]
+
+  implicit final val autoCloseableCanClose: CanClose[AutoCloseable] = _.close()
+
+}

--- a/extras-scala-io/src/main/scala-3/extras/scala/io/CanClose.scala
+++ b/extras-scala-io/src/main/scala-3/extras/scala/io/CanClose.scala
@@ -1,0 +1,20 @@
+package extras.scala.io
+
+/**
+ * @author Kevin Lee
+ * @since 2021-09-20
+ */
+trait CanClose[-A] extends scala.util.Using.Releasable[A] {
+
+  override def release(resource: A): Unit = close(resource)
+
+  def close(a: A): Unit
+}
+
+object CanClose {
+
+  def apply[A: CanClose]: CanClose[A] = summon[CanClose[A]]
+
+  given autoCloseableCanClose: CanClose[AutoCloseable] = _.close()
+
+}

--- a/extras-scala-io/src/test/scala-2.11_2.12/extras/scala/io/CanCloseSpec.scala
+++ b/extras-scala-io/src/test/scala-2.11_2.12/extras/scala/io/CanCloseSpec.scala
@@ -1,0 +1,71 @@
+package extras.scala.io
+
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2021-09-20
+  */
+object CanCloseSpec extends Properties {
+  override def tests: List[Test] = List(
+    example("testAutoCloseableCanClose", testAutoCloseableCanClose),
+    example("testMyResourceCanClose", testMyResourceCanClose)
+  )
+
+  def withCanClose[A: CanClose, B](a: A)(f: A => B): B =
+    try f(a)
+    finally CanClose[A].close(a)
+
+  final case class MyResource(value: String) {
+    private[this] var _closed: Boolean     = false
+    def closed: Boolean                    = _closed
+    def closed_=(newClosed: Boolean): Unit = {
+      _closed = newClosed
+      ()
+    }
+  }
+  object MyResource                          {
+    implicit final val myResourceCanClose: CanClose[MyResource] = new CanClose[MyResource] {
+      override def close(a: MyResource): Unit = a.closed = true
+    }
+  }
+
+  def testAutoCloseableCanClose: Result = {
+    var result: Option[String] = None
+    val autoCloseable          = new AutoCloseable {
+      override def close(): Unit = {
+        result = Some("Closed")
+        ()
+      }
+    }
+
+    val actual = withCanClose(autoCloseable)(_ => "Done")
+
+    Result.all(
+      List(
+        actual ==== "Done",
+        result ==== Some("Closed")
+      )
+    )
+  }
+
+  def testMyResourceCanClose: Result = {
+
+    val expected = "blah"
+
+    val autoCloseable = MyResource(expected)
+
+    val closedBefore = autoCloseable.closed ==== false
+
+    val actual = withCanClose(autoCloseable)(_.value)
+
+    Result.all(
+      List(
+        closedBefore,
+        actual ==== expected,
+        autoCloseable.closed ==== true
+      )
+    )
+  }
+
+}

--- a/extras-scala-io/src/test/scala-2.13/extras/scala/io/CanCloseSpec.scala
+++ b/extras-scala-io/src/test/scala-2.13/extras/scala/io/CanCloseSpec.scala
@@ -1,0 +1,116 @@
+package extras.scala.io
+
+import hedgehog._
+import hedgehog.runner._
+
+import scala.io.Source
+import scala.util.Using
+
+/** @author Kevin Lee
+  * @since 2021-09-20
+  */
+object CanCloseSpec extends Properties {
+  override def tests: List[Test] = List(
+    example("testAutoCloseableCanClose", testAutoCloseableCanClose),
+    example("testSourceCanClose", testSourceCanClose),
+    example("testMyResourceCanClose", testMyResourceCanClose),
+    example("testMyResourceCanCloseWithUsing", testMyResourceCanCloseWithUsing)
+  )
+
+  def withCanClose[A: CanClose, B](a: A)(f: A => B): B =
+    try f(a)
+    finally CanClose[A].close(a)
+
+  final case class MyResource(value: String) {
+    private[this] var _closed: Boolean     = false
+    def closed: Boolean                    = _closed
+    def closed_=(newClosed: Boolean): Unit = {
+      _closed = newClosed
+      ()
+    }
+  }
+  object MyResource                          {
+    implicit final val myResourceCanClose: CanClose[MyResource] =
+      _.closed = true
+  }
+
+  def testAutoCloseableCanClose: Result = {
+    var result: Option[String] = None
+    val autoCloseable          = new AutoCloseable {
+      override def close(): Unit = {
+        result = Some("Closed")
+        ()
+      }
+    }
+
+    val actual = withCanClose(autoCloseable)(_ => "Done")
+
+    Result.all(
+      List(
+        actual ==== "Done",
+        result ==== Some("Closed")
+      )
+    )
+  }
+
+  def testSourceCanClose: Result = {
+    var result: Option[String] = None
+
+    val expected = "abcde"
+
+    val autoCloseable = new Source {
+      override protected val iter: Iterator[Char] = expected.iterator
+    }.withClose({ () =>
+      result = Some("Closed")
+      ()
+    })
+
+    val actual = Using.resource(autoCloseable)(_.getLines().mkString)
+
+    Result.all(
+      List(
+        actual ==== expected,
+        result ==== Some("Closed")
+      )
+    )
+  }
+
+  def testMyResourceCanClose: Result = {
+
+    val expected = "blah"
+
+    val autoCloseable = MyResource(expected)
+
+    val closedBefore = autoCloseable.closed ==== false
+
+    val actual = withCanClose(autoCloseable)(_.value)
+
+    Result.all(
+      List(
+        closedBefore,
+        actual ==== expected,
+        autoCloseable.closed ==== true
+      )
+    )
+  }
+
+  def testMyResourceCanCloseWithUsing: Result = {
+
+    val expected = "blah"
+
+    val autoCloseable = MyResource(expected)
+
+    val closedBefore = autoCloseable.closed ==== false
+
+    val actual = Using.resource(autoCloseable)(_.value)
+
+    Result.all(
+      List(
+        closedBefore,
+        actual ==== expected,
+        autoCloseable.closed ==== true
+      )
+    )
+  }
+
+}

--- a/extras-scala-io/src/test/scala-3/extras/scala/io/CanCloseSpec.scala
+++ b/extras-scala-io/src/test/scala-3/extras/scala/io/CanCloseSpec.scala
@@ -1,0 +1,116 @@
+package extras.scala.io
+
+import hedgehog.*
+import hedgehog.runner.*
+
+import scala.io.Source
+import scala.util.Using
+
+/** @author Kevin Lee
+  * @since 2021-09-20
+  */
+object CanCloseSpec extends Properties {
+  override def tests: List[Test] = List(
+    example("testAutoCloseableCanClose", testAutoCloseableCanClose),
+    example("testSourceCanClose", testSourceCanClose),
+    example("testMyResourceCanClose", testMyResourceCanClose),
+    example("testMyResourceCanCloseWithUsing", testMyResourceCanCloseWithUsing)
+  )
+
+  def withCanClose[A: CanClose, B](a: A)(f: A => B): B =
+    try f(a)
+    finally CanClose[A].close(a)
+
+  final case class MyResource(value: String) {
+    private[this] var _closed: Boolean     = false
+    def closed: Boolean                    = _closed
+    def closed_=(newClosed: Boolean): Unit = {
+      _closed = newClosed
+      ()
+    }
+  }
+  object MyResource                          {
+    implicit final val myResourceCanClose: CanClose[MyResource] =
+      _.closed = true
+  }
+
+  def testAutoCloseableCanClose: Result = {
+    var result: Option[String] = None
+    val autoCloseable          = new AutoCloseable {
+      override def close(): Unit = {
+        result = Some("Closed")
+        ()
+      }
+    }
+
+    val actual = withCanClose(autoCloseable)(_ => "Done")
+
+    Result.all(
+      List(
+        actual ==== "Done",
+        result ==== Some("Closed")
+      )
+    )
+  }
+
+  def testSourceCanClose: Result = {
+    var result: Option[String] = None
+
+    val expected = "abcde"
+
+    val autoCloseable = new Source {
+      override protected val iter: Iterator[Char] = expected.iterator
+    }.withClose({ () =>
+      result = Some("Closed")
+      ()
+    })
+
+    val actual = Using.resource(autoCloseable)(_.getLines().mkString)
+
+    Result.all(
+      List(
+        actual ==== expected,
+        result ==== Some("Closed")
+      )
+    )
+  }
+
+  def testMyResourceCanClose: Result = {
+
+    val expected = "blah"
+
+    val autoCloseable = MyResource(expected)
+
+    val closedBefore = autoCloseable.closed ==== false
+
+    val actual = withCanClose(autoCloseable)(_.value)
+
+    Result.all(
+      List(
+        closedBefore,
+        actual ==== expected,
+        autoCloseable.closed ==== true
+      )
+    )
+  }
+
+  def testMyResourceCanCloseWithUsing: Result = {
+
+    val expected = "blah"
+
+    val autoCloseable = MyResource(expected)
+
+    val closedBefore = autoCloseable.closed ==== false
+
+    val actual = Using.resource(autoCloseable)(_.value)
+
+    Result.all(
+      List(
+        closedBefore,
+        actual ==== expected,
+        autoCloseable.closed ==== true
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
Close #28 - `CanClose[A]` type class as an alternative to `AutoCloseable`