### PR TITLE
Close #39 - Add a shorter name method for eitherT

### DIFF
--- a/extras-cats/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
+++ b/extras-cats/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
@@ -24,21 +24,23 @@ trait EitherSyntax {
 object EitherSyntax {
 
   final class EitherTFEitherOps[F[_], A, B](private val fOfEither: F[Either[A, B]]) extends AnyVal {
-    def eitherT: EitherT[F, A, B] = EitherT[F, A, B](fOfEither)
+    @inline def eitherT: EitherT[F, A, B] = EitherT[F, A, B](fOfEither)
+    @inline def t: EitherT[F, A, B] = eitherT
   }
 
   final class EitherTEitherOps[A, B](private val either: Either[A, B]) extends AnyVal {
-    def eitherT[F[_]: Applicative]: EitherT[F, A, B] = EitherT.fromEither[F](either)
+    @inline def eitherT[F[_]: Applicative]: EitherT[F, A, B] = EitherT.fromEither[F](either)
+    @inline def t[F[_]: Applicative]: EitherT[F, A, B] = eitherT[F]
   }
 
   final class EitherTFAOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def rightT[B](implicit F: Functor[F]): EitherT[F, B, A] = EitherT.right[B](fa)
-    def leftT[B](implicit F: Functor[F]): EitherT[F, A, B]  = EitherT.left[B](fa)
+    @inline def rightT[B](implicit F: Functor[F]): EitherT[F, B, A] = EitherT.right[B](fa)
+    @inline def leftT[B](implicit F: Functor[F]): EitherT[F, A, B]  = EitherT.left[B](fa)
   }
 
   final class EitherTAOps[A](private val a: A) extends AnyVal {
-    def rightTF[F[_]: Applicative, B]: EitherT[F, B, A] = EitherT.rightT[F, B](a)
-    def leftTF[F[_]: Applicative, B]: EitherT[F, A, B]  = EitherT.leftT[F, B](a)
+    @inline def rightTF[F[_]: Applicative, B]: EitherT[F, B, A] = EitherT.rightT[F, B](a)
+    @inline def leftTF[F[_]: Applicative, B]: EitherT[F, A, B]  = EitherT.leftT[F, B](a)
   }
 
 }

--- a/extras-cats/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/extras-cats/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -24,19 +24,21 @@ trait OptionSyntax {
 object OptionSyntax {
 
   final class OptionTFOptionOps[F[_], A](private val fOfOption: F[Option[A]]) extends AnyVal {
-    def optionT: OptionT[F, A] = OptionT[F, A](fOfOption)
+    @inline def optionT: OptionT[F, A] = OptionT[F, A](fOfOption)
+    @inline def t: OptionT[F, A] = optionT
   }
 
   final class OptionTOptionOps[A](private val option: Option[A]) extends AnyVal {
-    def optionT[F[_]: Applicative]: OptionT[F, A] = OptionT.fromOption[F](option)
+    @inline def optionT[F[_]: Applicative]: OptionT[F, A] = OptionT.fromOption[F](option)
+    @inline def t[F[_]: Applicative]: OptionT[F, A] = optionT[F]
   }
 
   final class OptionTFAOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def someT(implicit F: Functor[F]): OptionT[F, A] = OptionT.liftF(fa)
+    @inline def someT(implicit F: Functor[F]): OptionT[F, A] = OptionT.liftF(fa)
   }
 
   final class OptionTAOps[A](private val a: A) extends AnyVal {
-    def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
+    @inline def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
   }
 
 }

--- a/extras-cats/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
+++ b/extras-cats/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
@@ -9,21 +9,23 @@ import cats.data.EitherT
 trait EitherSyntax {
 
   extension [F[_], A, B](fOfEither: F[Either[A, B]]) {
-    def eitherT: EitherT[F, A, B] = EitherT[F, A, B](fOfEither)
+    inline def eitherT: EitherT[F, A, B] = EitherT[F, A, B](fOfEither)
+    inline def t: EitherT[F, A, B] = eitherT
   }
 
   extension [A, B](either: Either[A, B]) {
-    def eitherT[F[_]: Applicative]: EitherT[F, A, B] = EitherT.fromEither[F](either)
+    inline def eitherT[F[_]: Applicative]: EitherT[F, A, B] = EitherT.fromEither[F](either)
+    inline def t[F[_]: Applicative]: EitherT[F, A, B] = eitherT[F]
   }
 
   extension [F[_], A](fa: F[A]) {
-    def rightT[B](using F: Functor[F]): EitherT[F, B, A] = EitherT.right[B](fa)
-    def leftT[B](using F: Functor[F]): EitherT[F, A, B]  = EitherT.left[B](fa)
+    inline def rightT[B](using F: Functor[F]): EitherT[F, B, A] = EitherT.right[B](fa)
+    inline def leftT[B](using F: Functor[F]): EitherT[F, A, B]  = EitherT.left[B](fa)
   }
 
   extension [A](a: A) {
-    def rightTF[F[_]: Applicative, B]: EitherT[F, B, A] = EitherT.rightT[F, B](a)
-    def leftTF[F[_]: Applicative, B]: EitherT[F, A, B]  = EitherT.leftT[F, B](a)
+    inline def rightTF[F[_]: Applicative, B]: EitherT[F, B, A] = EitherT.rightT[F, B](a)
+    inline def leftTF[F[_]: Applicative, B]: EitherT[F, A, B]  = EitherT.leftT[F, B](a)
   }
 
 }

--- a/extras-cats/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/extras-cats/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -10,19 +10,21 @@ import cats.data.OptionT
 trait OptionSyntax {
 
   extension [F[_], A](fOfOption: F[Option[A]]) {
-    def optionT: OptionT[F, A] = OptionT[F, A](fOfOption)
+    inline def optionT: OptionT[F, A] = OptionT[F, A](fOfOption)
+    inline def t: OptionT[F, A] = optionT
   }
 
   extension [A](option: Option[A]) {
-    def optionT[F[_]: Applicative]: OptionT[F, A] = OptionT.fromOption[F](option)
+    inline def optionT[F[_]: Applicative]: OptionT[F, A] = OptionT.fromOption[F](option)
+    inline def t[F[_]: Applicative]: OptionT[F, A] = optionT[F]
   }
 
   extension [F[_], A](fa: F[A]) {
-    def someT(using F: Functor[F]): OptionT[F, A] = OptionT.liftF(fa)
+    inline def someT(using F: Functor[F]): OptionT[F, A] = OptionT.liftF(fa)
   }
 
   extension [A](a: A) {
-    def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
+    inline def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
   }
 
 }

--- a/extras-cats/src/test/scala-2/extras/cats/syntax/AllSyntaxSpec.scala
+++ b/extras-cats/src/test/scala-2/extras/cats/syntax/AllSyntaxSpec.scala
@@ -14,16 +14,24 @@ object AllSyntaxSpec extends Properties {
       OptionTFOptionOpsSpec.testOptionT
     ),
     property(
+      "OptionTFOptionOpsSpec.testT",
+      OptionTFOptionOpsSpec.testT
+    ),
+    property(
       "OptionTOptionOpsSpec.testOptionT",
       OptionTOptionOpsSpec.testOptionT
     ),
     property(
-      "OptionTFAOpsSpec.testOptionT",
-      OptionTFAOpsSpec.testOptionT
+      "OptionTOptionOpsSpec.testT",
+      OptionTOptionOpsSpec.testT
     ),
     property(
-      "OptionTAOpsSpec.testOptionTF",
-      OptionTAOpsSpec.testOptionTF
+      "OptionTFAOpsSpec.testSomeT",
+      OptionTFAOpsSpec.testSomeT
+    ),
+    property(
+      "OptionTAOpsSpec.testSomeTF",
+      OptionTAOpsSpec.testSomeTF
     ),
     property(
       "OptionTSupportAllSpec.testAll",
@@ -34,8 +42,16 @@ object AllSyntaxSpec extends Properties {
       EitherSyntaxSpec.testEitherT
     ),
     property(
+      "EitherSyntaxSpec.testT",
+      EitherSyntaxSpec.testT
+    ),
+    property(
       "EitherTEitherOpsSpec.testEitherT",
       EitherTEitherOpsSpec.testEitherT
+    ),
+    property(
+      "EitherTEitherOpsSpec.testT",
+      EitherTEitherOpsSpec.testT
     ),
     property(
       "EitherTFAOpsSpec.testRightT",
@@ -86,6 +102,24 @@ object AllSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = fab[IO, Int](n.some)
+      val expected      = OptionT(input)
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
   }
 
   object OptionTOptionOpsSpec {
@@ -114,6 +148,24 @@ object AllSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = n.some
+      val expected      = OptionT(Applicative[IO].pure(input))
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t[IO]
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
   }
 
   object OptionTFAOpsSpec {
@@ -123,7 +175,7 @@ object AllSyntaxSpec extends Properties {
     import cats.effect.IO
     import extras.cats.syntax.all.optionTFAOps
 
-    def testOptionT: Property = for {
+    def testSomeT: Property = for {
       n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
     } yield {
       val input         = Applicative[IO].pure(n)
@@ -151,7 +203,7 @@ object AllSyntaxSpec extends Properties {
     import cats.syntax.option._
     import extras.cats.syntax.all.optionTAOps
 
-    def testOptionTF: Property = for {
+    def testSomeTF: Property = for {
       n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
     } yield {
       val input         = n
@@ -191,12 +243,18 @@ object AllSyntaxSpec extends Properties {
       val actual1      = input1.optionT
       val actual1Value = actual1.value.unsafeRunSync()
 
+      val actual1_1      = input1.t
+      val actual1_1Value = actual1_1.value.unsafeRunSync()
+
       val input2         = n.some
       val expected2      = OptionT(Applicative[IO].pure(input2))
       val expected2Value = expected2.value.unsafeRunSync()
 
       val actual2      = input2.optionT[IO]
       val actual2Value = actual2.value.unsafeRunSync()
+
+      val actual2_1      = input2.t[IO]
+      val actual2_1Value = actual2_1.value.unsafeRunSync()
 
       val input3         = Applicative[IO].pure(n)
       val expected3      = OptionT.liftF(input3)
@@ -216,8 +274,12 @@ object AllSyntaxSpec extends Properties {
         List(
           Result.assert(actual1Value.isDefined).log(s"actual1Value should be Some. actual1Value: $actual1Value"),
           actual1Value ==== expected1Value,
+          Result.assert(actual1_1Value.isDefined).log(s"actual1Value should be Some. actual1_1Value: $actual1_1Value"),
+          actual1_1Value ==== expected1Value,
           Result.assert(actual2Value.isDefined).log(s"actual2Value should be Some. actual2Value: $actual2Value"),
           actual2Value ==== expected2Value,
+          Result.assert(actual2_1Value.isDefined).log(s"actual2Value should be Some. actual2_1Value: $actual2_1Value"),
+          actual2_1Value ==== expected2Value,
           Result.assert(actual3Value.isDefined).log(s"actual3Value should be Some. actual3Value: $actual3Value"),
           actual3Value ==== expected3Value,
           Result.assert(actual4Value.isDefined).log(s"actual4Value should be Some. actual4Value: $actual4Value"),
@@ -253,6 +315,21 @@ object AllSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input       = fab[IO, String, Int](n.asRight[String])
+      val expected    = EitherT(input)
+      val actual      = input.t
+      val actualValue = actual.value.unsafeRunSync()
+      Result.all(
+        List(
+          Result.assert(actualValue.isRight).log(s"actualValue should be Right. actualValue: $actualValue"),
+          actualValue ==== expected.value.unsafeRunSync()
+        )
+      )
+    }
+
   }
 
   object EitherTEitherOpsSpec {
@@ -279,6 +356,24 @@ object AllSyntaxSpec extends Properties {
         )
       )
     }
+
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input: Either[String, Int] = n.asRight[String]
+
+      val expected = EitherT(Applicative[IO].pure(input))
+
+      val actual      = input.t[IO]
+      val actualValue = actual.value.unsafeRunSync()
+      Result.all(
+        List(
+          Result.assert(actualValue.isRight).log(s"actualValue should be Right. actualValue: $actualValue"),
+          actualValue ==== expected.value.unsafeRunSync()
+        )
+      )
+    }
+
   }
 
   object EitherTFAOpsSpec {
@@ -389,12 +484,18 @@ object AllSyntaxSpec extends Properties {
       val actual1      = input1.eitherT
       val actual1Value = actual1.value.unsafeRunSync()
 
+      val actual1_1      = input1.t
+      val actual1_1Value = actual1_1.value.unsafeRunSync()
+
       val input2: Either[String, Int] = n.asRight[String]
       val expected2                   = EitherT(Applicative[IO].pure(input2))
       val expected2Value              = expected2.value.unsafeRunSync()
 
       val actual2      = input2.eitherT[IO]
       val actual2Value = actual2.value.unsafeRunSync()
+
+      val actual2_1      = input2.t[IO]
+      val actual2_1Value = actual2_1.value.unsafeRunSync()
 
       val input3         = IO(n)
       val expected3      = EitherT(input3.map(_.asRight[String]))
@@ -428,8 +529,12 @@ object AllSyntaxSpec extends Properties {
         List(
           Result.assert(actual1Value.isRight).log(s"actual1Value should be Right. actual1Value: $actual1Value"),
           actual1Value ==== expected1Value,
+          Result.assert(actual1_1Value.isRight).log(s"actual1_1Value should be Right. actual1_1Value: $actual1_1Value"),
+          actual1_1Value ==== expected1Value,
           Result.assert(actual2Value.isRight).log(s"actual2Value should be Right. actual2Value: $actual2Value"),
           actual2Value ==== expected2Value,
+          Result.assert(actual2_1Value.isRight).log(s"actual2_1Value should be Right. actual2_1Value: $actual2_1Value"),
+          actual2_1Value ==== expected2Value,
           Result.assert(actual3Value.isRight).log(s"actual3Value should be Right. actual3Value: $actual3Value"),
           actual3Value ==== expected3Value,
           Result.assert(actual4Value.isLeft).log(s"actual4Value should be Left. actual4Value: $actual4Value"),

--- a/extras-cats/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
+++ b/extras-cats/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
@@ -14,8 +14,16 @@ object EitherSyntaxSpec extends Properties {
       EitherSyntaxSpec.testEitherT
     ),
     property(
+      "EitherSyntaxSpec.testT",
+      EitherSyntaxSpec.testT
+    ),
+    property(
       "EitherTEitherOpsSpec.testEitherT",
       EitherTEitherOpsSpec.testEitherT
+    ),
+    property(
+      "EitherTEitherOpsSpec.testT",
+      EitherTEitherOpsSpec.testT
     ),
     property(
       "EitherTFAOpsSpec.testRightT",
@@ -63,6 +71,21 @@ object EitherSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input       = fab[IO, String, Int](n.asRight[String])
+      val expected    = EitherT(input)
+      val actual      = input.t
+      val actualValue = actual.value.unsafeRunSync()
+      Result.all(
+        List(
+          Result.assert(actualValue.isRight).log(s"actualValue should be Right. actualValue: $actualValue"),
+          actualValue ==== expected.value.unsafeRunSync()
+        )
+      )
+    }
+
   }
 
   object EitherTEitherOpsSpec {
@@ -89,6 +112,24 @@ object EitherSyntaxSpec extends Properties {
         )
       )
     }
+
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input: Either[String, Int] = n.asRight[String]
+
+      val expected = EitherT(Applicative[IO].pure(input))
+
+      val actual      = input.t[IO]
+      val actualValue = actual.value.unsafeRunSync()
+      Result.all(
+        List(
+          Result.assert(actualValue.isRight).log(s"actualValue should be Right. actualValue: $actualValue"),
+          actualValue ==== expected.value.unsafeRunSync()
+        )
+      )
+    }
+
   }
 
   object EitherTFAOpsSpec {
@@ -199,12 +240,18 @@ object EitherSyntaxSpec extends Properties {
       val actual1      = input1.eitherT
       val actual1Value = actual1.value.unsafeRunSync()
 
+      val actual1_1      = input1.t
+      val actual1_1Value = actual1_1.value.unsafeRunSync()
+
       val input2: Either[String, Int] = n.asRight[String]
       val expected2                   = EitherT(Applicative[IO].pure(input2))
       val expected2Value              = expected2.value.unsafeRunSync()
 
       val actual2      = input2.eitherT[IO]
       val actual2Value = actual2.value.unsafeRunSync()
+
+      val actual2_1      = input2.t[IO]
+      val actual2_1Value = actual2_1.value.unsafeRunSync()
 
       val input3         = IO(n)
       val expected3      = EitherT(input3.map(_.asRight[String]))
@@ -238,8 +285,12 @@ object EitherSyntaxSpec extends Properties {
         List(
           Result.assert(actual1Value.isRight).log(s"actual1Value should be Right. actual1Value: $actual1Value"),
           actual1Value ==== expected1Value,
+          Result.assert(actual1_1Value.isRight).log(s"actual1_1Value should be Right. actual1_1Value: $actual1_1Value"),
+          actual1_1Value ==== expected1Value,
           Result.assert(actual2Value.isRight).log(s"actual2Value should be Right. actual2Value: $actual2Value"),
           actual2Value ==== expected2Value,
+          Result.assert(actual2_1Value.isRight).log(s"actual2_1Value should be Right. actual2_1Value: $actual2_1Value"),
+          actual2_1Value ==== expected2Value,
           Result.assert(actual3Value.isRight).log(s"actual3Value should be Right. actual3Value: $actual3Value"),
           actual3Value ==== expected3Value,
           Result.assert(actual4Value.isLeft).log(s"actual4Value should be Left. actual4Value: $actual4Value"),

--- a/extras-cats/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/extras-cats/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -13,8 +13,16 @@ object OptionSyntaxSpec extends Properties {
       OptionTFOptionOpsSpec.testOptionT
     ),
     property(
+      "OptionTFOptionOpsSpec.testT",
+      OptionTFOptionOpsSpec.testT
+    ),
+    property(
       "OptionTOptionOpsSpec.testOptionT",
       OptionTOptionOpsSpec.testOptionT
+    ),
+    property(
+      "OptionTOptionOpsSpec.testT",
+      OptionTOptionOpsSpec.testT
     ),
     property(
       "OptionTFAOpsSpec.testOptionT",
@@ -57,6 +65,24 @@ object OptionSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = fab[IO, Int](n.some)
+      val expected      = OptionT(input)
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
   }
 
   object OptionTOptionOpsSpec {
@@ -75,6 +101,24 @@ object OptionSyntaxSpec extends Properties {
       val expectedValue = expected.value.unsafeRunSync()
 
       val actual      = input.optionT[IO]
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = n.some
+      val expected      = OptionT(Applicative[IO].pure(input))
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t[IO]
       val actualValue = actual.value.unsafeRunSync()
 
       Result.all(
@@ -162,12 +206,18 @@ object OptionSyntaxSpec extends Properties {
       val actual1      = input1.optionT
       val actual1Value = actual1.value.unsafeRunSync()
 
+      val actual1_1      = input1.t
+      val actual1_1Value = actual1_1.value.unsafeRunSync()
+
       val input2         = n.some
       val expected2      = OptionT(Applicative[IO].pure(input2))
       val expected2Value = expected2.value.unsafeRunSync()
 
       val actual2      = input2.optionT[IO]
       val actual2Value = actual2.value.unsafeRunSync()
+
+      val actual2_1      = input2.t[IO]
+      val actual2_1Value = actual2_1.value.unsafeRunSync()
 
       val input3         = Applicative[IO].pure(n)
       val expected3      = OptionT.liftF(input3)
@@ -187,8 +237,16 @@ object OptionSyntaxSpec extends Properties {
         List(
           Result.assert(actual1Value.isDefined).log(s"actual1Value should be Some. actual1Value: $actual1Value"),
           actual1Value ==== expected1Value,
+          Result
+            .assert(actual1_1Value.isDefined)
+            .log(s"actual1_1Value should be Some. actual1_1Value: $actual1_1Value"),
+          actual1_1Value ==== expected1Value,
           Result.assert(actual2Value.isDefined).log(s"actual2Value should be Some. actual2Value: $actual2Value"),
           actual2Value ==== expected2Value,
+          Result
+            .assert(actual2_1Value.isDefined)
+            .log(s"actual2_1Value should be Some. actual2_1Value: $actual2_1Value"),
+          actual2_1Value ==== expected2Value,
           Result.assert(actual3Value.isDefined).log(s"actual3Value should be Some. actual3Value: $actual3Value"),
           actual3Value ==== expected3Value,
           Result.assert(actual4Value.isDefined).log(s"actual4Value should be Some. actual4Value: $actual4Value"),

--- a/extras-cats/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/extras-cats/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -16,8 +16,16 @@ object OptionSyntaxSpec extends Properties {
       OptionTFOptionOpsSpec.testOptionT
     ),
     property(
+      "OptionTFOptionOpsSpec.testT",
+      OptionTFOptionOpsSpec.testT
+    ),
+    property(
       "OptionTOptionOpsSpec.testOptionT",
       OptionTOptionOpsSpec.testOptionT
+    ),
+    property(
+      "OptionTOptionOpsSpec.testT",
+      OptionTOptionOpsSpec.testT
     ),
     property(
       "OptionTFAOpsSpec.testOptionT",
@@ -40,7 +48,7 @@ object OptionSyntaxSpec extends Properties {
     import cats.data.*
     import cats.effect.*
     import cats.syntax.option.*
-    import extras.cats.syntax.option.optionT
+    import extras.cats.syntax.option.{optionT, t}
 
     def fab[F[_]: Sync, A](oa: Option[A]): F[Option[A]] = Sync[F].delay(oa)
 
@@ -62,6 +70,24 @@ object OptionSyntaxSpec extends Properties {
       )
     }
 
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = fab[IO, Int](n.some)
+      val expected      = OptionT(input)
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
   }
 
   object OptionTOptionOpsSpec {
@@ -72,7 +98,7 @@ object OptionSyntaxSpec extends Properties {
     import cats.data.OptionT
     import cats.effect.IO
     import cats.syntax.option.*
-    import extras.cats.syntax.option.optionT
+    import extras.cats.syntax.option.{optionT, t}
 
     def testOptionT: Property = for {
       n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
@@ -82,6 +108,24 @@ object OptionSyntaxSpec extends Properties {
       val expectedValue = expected.value.unsafeRunSync()
 
       val actual      = input.optionT[IO]
+      val actualValue = actual.value.unsafeRunSync()
+
+      Result.all(
+        List(
+          Result.assert(actualValue.isDefined).log(s"actualValue should be Some. actualValue: $actualValue"),
+          actualValue ==== expectedValue
+        )
+      )
+    }
+
+    def testT: Property = for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      val input         = n.some
+      val expected      = OptionT(Applicative[IO].pure(input))
+      val expectedValue = expected.value.unsafeRunSync()
+
+      val actual      = input.t[IO]
       val actualValue = actual.value.unsafeRunSync()
 
       Result.all(
@@ -175,12 +219,18 @@ object OptionSyntaxSpec extends Properties {
       val actual1      = input1.optionT
       val actual1Value = actual1.value.unsafeRunSync()
 
+      val actual1_1      = input1.optionT
+      val actual1_1Value = actual1_1.value.unsafeRunSync()
+
       val input2         = n.some
       val expected2      = OptionT(Applicative[IO].pure(input2))
       val expected2Value = expected2.value.unsafeRunSync()
 
       val actual2      = input2.optionT[IO]
       val actual2Value = actual2.value.unsafeRunSync()
+
+      val actual2_1      = input2.optionT[IO]
+      val actual2_1Value = actual2_1.value.unsafeRunSync()
 
       val input3         = Applicative[IO].pure(n)
       val expected3      = OptionT.liftF(input3)
@@ -200,8 +250,12 @@ object OptionSyntaxSpec extends Properties {
         List(
           Result.assert(actual1Value.isDefined).log(s"actual1Value should be Some. actual1Value: $actual1Value"),
           actual1Value ==== expected1Value,
+          Result.assert(actual1_1Value.isDefined).log(s"actual1_1Value should be Some. actual1_1Value: $actual1_1Value"),
+          actual1_1Value ==== expected1Value,
           Result.assert(actual2Value.isDefined).log(s"actual2Value should be Some. actual2Value: $actual2Value"),
           actual2Value ==== expected2Value,
+          Result.assert(actual2_1Value.isDefined).log(s"actual2_1Value should be Some. actual2_1Value: $actual2_1Value"),
+          actual2_1Value ==== expected2Value,
           Result.assert(actual3Value.isDefined).log(s"actual3Value should be Some. actual3Value: $actual3Value"),
           actual3Value ==== expected3Value,
           Result.assert(actual4Value.isDefined).log(s"actual4Value should be Some. actual4Value: $actual4Value"),


### PR DESCRIPTION
Close #39 - Add a shorter name method for `eitherT`