### PR TITLE
extras v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,11 @@
+## [0.2.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone2) - 2021-11-14
+
+## Done
+* Create the doc site (#23)(#34)
+* Add `extras-scala-io` (#24)
+  * Add typed version of `scala.io.AnsiColor` to `extras-scala-io` (#26)
+  * `ColorSyntax` for typed `AnsiColor` (#27)
+  * `CanClose[A]` type class as an alternative to `AutoCloseable` (#28)
+* Redesign `extras-concurrent-testing` APIs (#36)
+* Add a shorter name method for `eitherT` (#39)
+* Add `syntax` for testing `Future` (#41)


### PR DESCRIPTION
# extras v0.2.0
## [0.2.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone2) - 2021-11-14

## Done
* Create the doc site (#23)(#34)
* Add `extras-scala-io` (#24)
  * Add typed version of `scala.io.AnsiColor` to `extras-scala-io` (#26)
  * `ColorSyntax` for typed `AnsiColor` (#27)
  * `CanClose[A]` type class as an alternative to `AutoCloseable` (#28)
* Redesign `extras-concurrent-testing` APIs (#36)
* Add a shorter name method for `eitherT` (#39)
* Add `syntax` for testing `Future` (#41)
