### PR TITLE
Close #75 - CatsEffectRunner.IoOps.expectError should take Eq and Show for the expected error

### DIFF
--- a/extras-hedgehog-cats-effect3/src/test/scala/extras/hedgehog/cats/effect/CatsEffectRunnerSpec.scala
+++ b/extras-hedgehog-cats-effect3/src/test/scala/extras/hedgehog/cats/effect/CatsEffectRunnerSpec.scala
@@ -1,6 +1,6 @@
 package extras.hedgehog.cats.effect
 
-import cats.Eq
+import cats.{Eq, Show}
 import cats.effect.IO
 import hedgehog._
 import hedgehog.runner._
@@ -89,6 +89,7 @@ object CatsEffectRunnerSpec extends Properties {
     def anotherTestError(message: String): TestError = AnotherTestError(message)
     def someTestError(message: String): TestError    = SomeTestError(message)
 
-    implicit val testErrorEq: Eq[TestError] = Eq.fromUniversalEquals
+    implicit val testErrorEq: Eq[TestError]     = Eq.fromUniversalEquals
+    implicit val testErrorShow: Show[TestError] = Show.fromToString
   }
 }


### PR DESCRIPTION
Close #75 - `CatsEffectRunner.IoOps.expectError` should take `Eq` and `Show` for the expected error