### PR TITLE
extras v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,7 @@
+## [0.4.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone4) - 2021-12-22
+
+## Done
+* Add a way to test `IO[A]` - `IO[A].completeThen(A => Result): Result` (#71)
+* Add a way to test `IO[A]` with error - `IO[A].errorThen(Throwable => Result): Result` (#73)
+* `CatsEffectRunner.IoOps.expectError` should take `Eq` and `Show` for the expected error (#75)
+* Publish to [s01.oss.sonatype.org](https://s01.oss.sonatype.org) (the new Maven central) (#67)


### PR DESCRIPTION
# extras v0.4.0
## [0.4.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone4) - 2021-12-22

## Done
* Add a way to test `IO[A]` - `IO[A].completeThen(A => Result): Result` (#71)
* Add a way to test `IO[A]` with error - `IO[A].errorThen(Throwable => Result): Result` (#73)
* `CatsEffectRunner.IoOps.expectError` should take `Eq` and `Show` for the expected error (#75)
* Publish to [s01.oss.sonatype.org](https://s01.oss.sonatype.org) (the new Maven central) (#67)
