### PR TITLE
extras v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,7 @@
+## [0.5.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone5) - 2022-03-06
+
+## Done
+* Set up Codecov in GitHub Actions (#83)
+* Add Scalafix check (#92)
+* Support Scala.js (#95)
+* Move all sub-projects to `modules` (#97)


### PR DESCRIPTION
# extras v0.5.0
## [0.5.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone5) - 2022-03-06

## Done
* Set up Codecov in GitHub Actions (#83)
* Add Scalafix check (#92)
* Support Scala.js (#95)
* Move all sub-projects to `modules` (#97)
