### PR TITLE
extras v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,5 @@
+## [0.6.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone6) - 2022-03-15
+
+## Done
+* Add syntax to support `newtype` and `refined` (#101)
+  * `extras-reflects` and `extras-refinement` have been added.


### PR DESCRIPTION
# extras v0.6.0
## [0.6.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone6) - 2022-03-15

## Done
* Add syntax to support `newtype` and `refined` (#101)
  * `extras-reflects` and `extras-refinement` have been added.
