### PR TITLE
Close #105 - Change extension method for refinement type + newtype from `value.as[A].validate` to `value.validateAs[A]`

### DIFF
--- a/modules/extras-refinement/shared/src/main/scala/extras/refinement/syntax/refinement.scala
+++ b/modules/extras-refinement/shared/src/main/scala/extras/refinement/syntax/refinement.scala
@@ -13,7 +13,7 @@ trait refinement {
 
   def validateAs[A]: PartiallyAppliedRefinement[A] = new PartiallyAppliedRefinement[A]()
 
-  implicit def refinementSyntax[T](value: T): RefinementSyntax[T] = new RefinementSyntax(value)
+  implicit def refinementSyntax[T, P](value: T): RefinementSyntax[T, P] = new RefinementSyntax(value)
 }
 
 object refinement extends refinement { self =>
@@ -31,17 +31,12 @@ object refinement extends refinement { self =>
         .map(_.coerce[A])
   }
 
-  private[refinement] final class PartiallyAppliedRefinementForSyntax[A, T](private val value: T) extends AnyVal {
-    def validate[P](
+  private[refinement] final class RefinementSyntax[T, P](private val value: T) extends AnyVal {
+    def validateAs[A](
       implicit coercible: Coercible[Refined[T, P], A],
       validate: Validate[T, P],
       tt: WeakTypeTag[A]
-    ): EitherNel[String, A] =
-      self.validateAs[A](value)
-  }
-
-  final class RefinementSyntax[T](private val t: T) extends AnyVal {
-    def as[A]: PartiallyAppliedRefinementForSyntax[A, T] = new PartiallyAppliedRefinementForSyntax[A, T](t)
+    ): EitherNel[String, A] = self.validateAs[A](value)
   }
 
 }

--- a/modules/extras-refinement/shared/src/test/scala/extras/refinement/syntax/refinementSpec.scala
+++ b/modules/extras-refinement/shared/src/test/scala/extras/refinement/syntax/refinementSpec.scala
@@ -37,7 +37,7 @@ object refinementSpec extends Properties {
   } yield {
     import TypesForTesting._
     import extras.refinement.syntax.refinement._
-    val actual = nonEmptyString.as[Name].validate
+    val actual = nonEmptyString.validateAs[Name]
     actual ==== Right(Name(NonEmptyString.unsafeFrom(nonEmptyString)))
   }
 
@@ -53,7 +53,7 @@ object refinementSpec extends Properties {
     import TypesForTesting._
     import extras.refinement.syntax.refinement._
     val input  = ""
-    val actual = input.as[Name].validate
+    val actual = input.validateAs[Name]
     actual ==== Left(NonEmptyList.of("Failed to create TypesForTesting.Name: Predicate isEmpty() did not fail."))
   }
 
@@ -71,7 +71,7 @@ object refinementSpec extends Properties {
   } yield {
     import TypesForTesting._
     import extras.refinement.syntax.refinement._
-    val actual = positiveInt.as[Id].validate
+    val actual = positiveInt.validateAs[Id]
     actual ==== Right(Id(PositiveInt.unsafeFrom(positiveInt)))
   }
 
@@ -89,7 +89,7 @@ object refinementSpec extends Properties {
   } yield {
     import TypesForTesting._
     import extras.refinement.syntax.refinement._
-    val actual = nonPositiveInt.as[Id].validate
+    val actual = nonPositiveInt.validateAs[Id]
     actual ==== Left(NonEmptyList.of(s"Failed to create TypesForTesting.Id: Predicate failed: ($nonPositiveInt > 0)."))
   }
 


### PR DESCRIPTION
Close #105 - Change extension method for refinement type + newtype from `value.as[A].validate` to `value.validateAs[A]`