### PR TITLE
extras v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,5 @@
+## [0.7.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone7) - 2022-03-15
+
+## Done
+* Change extension method for refinement type + newtype from `value.as[A].validate` to `value.validateAs[A]` (#105)
+ 


### PR DESCRIPTION
# extras v0.7.0
## [0.7.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone7) - 2022-03-15

## Done
* Change extension method for refinement type + newtype from `value.as[A].validate` to `value.validateAs[A]` (#105)
