### PR TITLE
extras v0.9.0

### DIFF
--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,4 @@
+## [0.9.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone9) - 2022-03-19
+
+## Done
+* [`extras-refinement`] Replace `EitherNel` with `EitherNec` ([more performant](https://typelevel.org/blog/2018/09/04/chain-replacing-the-list-monoid.html)) (#115)


### PR DESCRIPTION
# extras v0.9.0
## [0.9.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone9) - 2022-03-19

## Done
* [`extras-refinement`] Replace `EitherNel` with `EitherNec` ([more performant](https://typelevel.org/blog/2018/09/04/chain-replacing-the-list-monoid.html)) (#115)
