### PR TITLE
extras v0.13.0

### DIFF
--- a/changelogs/0.13.0.md
+++ b/changelogs/0.13.0.md
@@ -1,0 +1,6 @@
+## [0.13.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone13) - 2022-03-26
+
+## Done
+* [`extras-scala-io`] Change `file.ops` to `file.syntax` (#137)
+* [`extras-scala-io`] Change `getAllFiles` to `listAllFilesRecursively` (#138)
+* [`extras-scala-io`] Change `deleteFileRecursively` to `deleteAllRecursively` (#139)


### PR DESCRIPTION
# extras v0.13.0
## [0.13.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone13) - 2022-03-26

## Done
* [`extras-scala-io`] Change `file.ops` to `file.syntax` (#137)
* [`extras-scala-io`] Change `getAllFiles` to `listAllFilesRecursively` (#138)
* [`extras-scala-io`] Change `deleteFileRecursively` to `deleteAllRecursively` (#139)
