### PR TITLE
extras v0.14.0

### DIFF
--- a/changelogs/0.14.0.md
+++ b/changelogs/0.14.0.md
@@ -1,0 +1,4 @@
+## [0.14.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone14) - 2022-05-13
+
+## Done
+* Add `toValue` for `newtype` containing `refined` type to get the underlying value (#149)


### PR DESCRIPTION
# extras v0.14.0
## [0.14.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone14) - 2022-05-13

## Done
* Add `toValue` for `newtype` containing `refined` type to get the underlying value (#149)
