### PR TITLE
extras v0.15.0

### DIFF
--- a/changelogs/0.15.0.md
+++ b/changelogs/0.15.0.md
@@ -1,0 +1,4 @@
+## [0.15.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone15) - 2022-06-12
+
+## Done
+* [`extras-scala-io`] Add more `String.color` to `color` syntax (#158)


### PR DESCRIPTION
# extras v0.15.0
## [0.15.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone15) - 2022-06-12

## Done
* [`extras-scala-io`] Add more `String.color` to `color` syntax (#158)
