### PR TITLE
extras v0.16.0

### DIFF
--- a/changelogs/0.16.0.md
+++ b/changelogs/0.16.0.md
@@ -1,0 +1,14 @@
+## [0.16.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone16) - 2022-06-19
+
+## Done
+* [`extras-scala-io`] Add `Rgb` to have true color support (#162)
+  ```scala
+  Rgb.fromInt(0x000000) // Right(Rgb(0))
+  Rgb.fromInt(0xff0000) // Right(Rgb(16711680))
+  Rgb.fromInt(0x00ff00) // Right(Rgb(65280))
+  Rgb.fromInt(0x0000ff) // Right(Rgb(255))
+  Rgb.fromInt(0xffffff) // Right(Rgb(16777215))
+  // and more smart constructors and extension methods to get ASCII escape chars and HTML colors (hex)
+  ```
+* [`extras-scala-io`] Add a way to paint `String` with rainbow 🌈 colors (#161)
+  <img width="1207" alt="Screen Shot 2022-06-18 at 7 00 16 pm" src="https://user-images.githubusercontent.com/2307335/174430754-07c3dc74-1b1f-48f6-b32f-4c8ab2b8a81c.png">


### PR DESCRIPTION
# extras v0.16.0
## [0.16.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone16) - 2022-06-19

## Done
* [`extras-scala-io`] Add `Rgb` to have true color support (#162)
  ```scala
  Rgb.fromInt(0x000000) // Right(Rgb(0))
  Rgb.fromInt(0xff0000) // Right(Rgb(16711680))
  Rgb.fromInt(0x00ff00) // Right(Rgb(65280))
  Rgb.fromInt(0x0000ff) // Right(Rgb(255))
  Rgb.fromInt(0xffffff) // Right(Rgb(16777215))
  // and more smart constructors and extension methods to get ASCII escape chars and HTML colors (hex)
  ```
* [`extras-scala-io`] Add a way to paint `String` with rainbow 🌈 colors (#161)
  <img width="1207" alt="Screen Shot 2022-06-18 at 7 00 16 pm" src="https://user-images.githubusercontent.com/2307335/174430754-07c3dc74-1b1f-48f6-b32f-4c8ab2b8a81c.png">