### PR TITLE
Close #170 - [`extras-scala-io`] `extras.scala.io.syntax.color` `"".colored(Color)` should return `""`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,9 @@ lazy val extrasScalaIo = crossSubProject("scala-io", crossProject(JVMPlatform, J
         Seq.empty
     },
   )
+  .dependsOn(
+    extrasCore,
+  )
 
 lazy val extrasScalaIoJvm = extrasScalaIo.jvm
 lazy val extrasScalaIoJs  = extrasScalaIo.js.settings(Test / fork := false)

--- a/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/syntax/ColorSyntax.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/syntax/ColorSyntax.scala
@@ -15,7 +15,7 @@ object ColorSyntax {
   final class ColorOps(private val text: String) extends AnyVal {
 
     def colored(color: Color): String =
-      s"${color.toAnsi}$text${Color.reset.toAnsi}"
+      if (text.isEmpty) text else s"${color.toAnsi}$text${Color.reset.toAnsi}"
 
     def black: String         = colored(Color.black)
     def red: String           = colored(Color.red)

--- a/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/syntax/ColorSyntax.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/syntax/ColorSyntax.scala
@@ -10,7 +10,7 @@ trait ColorSyntax {
   extension (text: String) {
 
     def colored(color: Color): String =
-      s"${color.toAnsi}$text${Color.Reset.toAnsi}"
+      if text.isEmpty then text else s"${color.toAnsi}$text${Color.Reset.toAnsi}"
 
     def black: String         = colored(Color.black)
     def red: String           = colored(Color.red)

--- a/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/ColorSyntaxSpec.scala
+++ b/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/ColorSyntaxSpec.scala
@@ -1,6 +1,6 @@
 package extras.scala.io.syntax
 
-import extras.scala.io.ColorGens
+import extras.scala.io.{Color, ColorGens}
 import hedgehog.runner._
 import hedgehog._
 
@@ -12,6 +12,7 @@ import scala.io.AnsiColor
 object ColorSyntaxSpec extends Properties {
   override def tests: List[Test] = List(
     property("test text.colored(Color)", testColored),
+    property("an empty String.colored(Color) should return an empty String", testEmptyStringColored),
     property("test txt.black", testBlack),
     property("test txt.red", testRed),
     property("test txt.green", testGreen),
@@ -49,6 +50,41 @@ object ColorSyntaxSpec extends Properties {
     val actual             = text.colored(color)
     val expected           = colorAndReset(text, ansiColor)
     actual ==== expected
+  }
+
+  def testEmptyStringColored: Property = for {
+    color <- Gen
+               .element1(
+                 Color.black,
+                 Color.red,
+                 Color.green,
+                 Color.yellow,
+                 Color.blue,
+                 Color.magenta,
+                 Color.cyan,
+                 Color.white,
+                 Color.blackBg,
+                 Color.redBg,
+                 Color.greenBg,
+                 Color.yellowBg,
+                 Color.blueBg,
+                 Color.magentaBg,
+                 Color.cyanBg,
+                 Color.whiteBg,
+                 Color.reset,
+                 Color.bold,
+                 Color.underlined,
+                 Color.blink,
+                 Color.reversed,
+                 Color.invisible
+               )
+               .log("color")
+  } yield {
+    val expected = ""
+    val actual   = "".colored(color)
+    import extras.core.syntax.string._
+    (actual ==== expected)
+      .log(s"""${actual.encodeToUnicode} should be "" (an empty String)""")
   }
 
   def testBlack: Property = for {


### PR DESCRIPTION
Close #170 - [`extras-scala-io`] `extras.scala.io.syntax.color` `"".colored(Color)` should return `""`