### PR TITLE
Close #176 and Close #177 - [`extras-scala-io`] `Rgb.color("")`, `Rgb.colored("")`, `"".rgb` and `"".rgbed` should return `""`

### DIFF
--- a/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/truecolor/Rgb.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/truecolor/Rgb.scala
@@ -126,8 +126,8 @@ object Rgb {
     def toAsciiEsc: String         =
       s"\u001b[38;2;${rgb.red.value.toString};${rgb.green.value.toString};${rgb.blue.value.toString}m"
 
-    def color(s: String): String = toAsciiEsc + s
+    def color(s: String): String = if (s.isEmpty) "" else toAsciiEsc + s
 
-    def colored(s: String): String = toAsciiEsc + s + extras.scala.io.Color.Reset.toAnsi
+    def colored(s: String): String = if (s.isEmpty) "" else toAsciiEsc + s + extras.scala.io.Color.Reset.toAnsi
   }
 }

--- a/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/truecolor/Rgb.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/truecolor/Rgb.scala
@@ -170,8 +170,8 @@ object Rgb {
     def toAsciiEsc: String         =
       s"\u001b[38;2;${rgb.red.value.toString};${rgb.green.value.toString};${rgb.blue.value.toString}m"
 
-    def color(s: String): String = toAsciiEsc + s
+    def color(s: String): String = if s.isEmpty then "" else toAsciiEsc + s
 
-    def colored(s: String): String = toAsciiEsc + s + extras.scala.io.Color.Reset.toAnsi
+    def colored(s: String): String = if s.isEmpty then "" else toAsciiEsc + s + extras.scala.io.Color.Reset.toAnsi
   }
 }

--- a/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/truecolor/RgbSyntaxSpec.scala
+++ b/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/truecolor/RgbSyntaxSpec.scala
@@ -30,6 +30,10 @@ object RgbSyntaxSpec extends Properties {
       testRgbIntGreaterThan0xffffff
     ),
     property(
+      """"".rgb(Int) should return """"",
+      testEmptyStringRgbInt
+    ),
+    property(
       """String value.rgbed(Int) should return value in colored String value with ASCII escape chars ending with scala.io.AnsiColor.RESET""",
       testRgbedInt
     ),
@@ -40,6 +44,10 @@ object RgbSyntaxSpec extends Properties {
     property(
       """String value.rgbed(Int > 0xffffff) should return value in colored ASCII escaped String value with 0xffffff ending with scala.io.AnsiColor.RESET""",
       testRgbedIntGreaterThan0xffffff
+    ),
+    property(
+      """"".rgbed(Int) should return """"",
+      testEmptyStringRgbedInt
     )
   )
 
@@ -99,6 +107,17 @@ object RgbSyntaxSpec extends Properties {
     actual ==== expected
   }
 
+  def testEmptyStringRgbInt: Property = for {
+    intValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("intValue")
+  } yield {
+    import extras.scala.io.syntax.truecolor.rgb._
+    val expected = ""
+    val actual   = "".rgb(intValue)
+    import extras.core.syntax.string._
+    (actual ==== expected)
+      .log(s"""${actual.encodeToUnicode} should be """"")
+  }
+
   def testRgbedInt: Property = for {
     rgbInput <- Gens.genRgbIntAndInts.log("(rgbInt, (redInt, greenInt, blueInt))")
     (rgbInt, (redInt, greenInt, blueInt)) = rgbInput
@@ -128,6 +147,17 @@ object RgbSyntaxSpec extends Properties {
     val expected = TestTools.toRgbAsciiEsc(255, 255, 255) + text + extras.scala.io.Color.reset.toAnsi
     val actual   = text.rgbed(invalidRgbInt)
     actual ==== expected
+  }
+
+  def testEmptyStringRgbedInt: Property = for {
+    intValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("intValue")
+  } yield {
+    import extras.scala.io.syntax.truecolor.rgb._
+    val expected = ""
+    val actual   = "".rgbed(intValue)
+    import extras.core.syntax.string._
+    (actual ==== expected)
+      .log(s"""${actual.encodeToUnicode} should be """"")
   }
 
 }

--- a/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/truecolor/RgbSpec.scala
+++ b/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/truecolor/RgbSpec.scala
@@ -53,8 +53,16 @@ object RgbSpec extends Properties with CrossVersionRgbSpec {
       testColor
     ),
     property(
+      """Rgb(value).color("") should return """"",
+      testColorEmptyString
+    ),
+    property(
       """Rgb(value).colored(String value) should return value in colored String value with ASCII escape chars ending with scala.io.AnsiColor.RESET""",
       testColored
+    ),
+    property(
+      """Rgb(value).colored("") should return """"",
+      testColoredEmptyString
     )
   ) ++ corssVersionTests
 
@@ -516,6 +524,18 @@ object RgbSpec extends Properties with CrossVersionRgbSpec {
     actual ==== expected
   }
 
+  def testColorEmptyString: Property = for {
+    rgbInput <-
+      Gens.genRgbIntAndInts.log("(rgbInt, (expectedRed, expectedGreen, expectedBlue))")
+    (rgbInt, _) = rgbInput
+  } yield {
+    val expected = ""
+    val actual   = Rgb.unsafeFromInt(rgbInt).color("")
+    import extras.core.syntax.string._
+    (actual ==== expected)
+      .log(s"""${actual.encodeToUnicode} should be """"")
+  }
+
   def testColored: Property = for {
     rgbInput <-
       Gens.genRgbIntAndInts.log("(rgbInt, (expectedRed, expectedGreen, expectedBlue))")
@@ -531,6 +551,18 @@ object RgbSpec extends Properties with CrossVersionRgbSpec {
         .toAnsi
     val actual   = Rgb.unsafeFromInt(rgbInt).colored(text)
     actual ==== expected
+  }
+
+  def testColoredEmptyString: Property = for {
+    rgbInput <-
+      Gens.genRgbIntAndInts.log("(rgbInt, (expectedRed, expectedGreen, expectedBlue))")
+    (rgbInt, _) = rgbInput
+  } yield {
+    val expected = ""
+    val actual   = Rgb.unsafeFromInt(rgbInt).colored("")
+    import extras.core.syntax.string._
+    (actual ==== expected)
+      .log(s"""${actual.encodeToUnicode} should be """"")
   }
 
 }


### PR DESCRIPTION
Close #176 - [`extras-scala-io`] `Rgb.color("")` and `Rgb.colored("")` should return `""`
Close #177 - [`extras-scala-io`] `"".rgb` and `"".rgbed` should return `""`
