### PR TITLE
extras v0.17.0

### DIFF
--- a/changelogs/0.17.0.md
+++ b/changelogs/0.17.0.md
@@ -1,0 +1,10 @@
+## [0.17.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone17) - 2022-06-26
+
+## Done
+* [`extras-core`] Add `syntax` to encode `String` to escaped unicode chars (#172)
+* [`extras-scala-io`] `extras.scala.io.syntax.color` `"".colored(Color)` should return `""` (#170)
+* [`extras-scala-io`] Add `color` and `colored` to `Color` (#175)
+* [`extras-scala-io`] `Rgb.color("")` and `Rgb.colored("")` should return `""` (#176)
+* [`extras-scala-io`] `"".rgb` and `"".rgbed` should return `""` (#177)
+* [`extras-scala-io`] `Rainbow.rainbow("")` and `Rainbow.rainbowHtml("")` should return `""` (#180)
+* [`extras-scala-io`] `"".rainbowed` and `"".rainbowedHtml` should return `""` (#181)


### PR DESCRIPTION
# extras v0.17.0
## [0.17.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone17) - 2022-06-26

## Done
* [`extras-core`] Add `syntax` to encode `String` to escaped unicode chars (#172)
* [`extras-scala-io`] `extras.scala.io.syntax.color` `"".colored(Color)` should return `""` (#170)
* [`extras-scala-io`] Add `color` and `colored` to `Color` (#175)
* [`extras-scala-io`] `Rgb.color("")` and `Rgb.colored("")` should return `""` (#176)
* [`extras-scala-io`] `"".rgb` and `"".rgbed` should return `""` (#177)
* [`extras-scala-io`] `Rainbow.rainbow("")` and `Rainbow.rainbowHtml("")` should return `""` (#180)
* [`extras-scala-io`] `"".rainbowed` and `"".rainbowedHtml` should return `""` (#181)