### PR TITLE
extras v0.18.0

### DIFF
--- a/changelogs/0.18.0.md
+++ b/changelogs/0.18.0.md
@@ -1,0 +1,5 @@
+## [0.18.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone18) - 2022-07-08
+
+## Done
+* [`extras-scala-io`] Add `Rainbow.rainbows(Seq[String])` (#186)
+* [`extras-scala-io`] Add syntax: `Seq[String].rainbowed` (#188)


### PR DESCRIPTION
# extras v0.18.0
## [0.18.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone18) - 2022-07-08

## Done
* [`extras-scala-io`] Add `Rainbow.rainbows(Seq[String])` (#186)
* [`extras-scala-io`] Add syntax: `Seq[String].rainbowed` (#188)
