### PR TITLE
Close #191 - Remove -XX:+UseJVMCICompiler from .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -4,4 +4,3 @@
 -Xmx2G
 -XX:MaxInlineLevel=18
 -XX:+UnlockExperimentalVMOptions
--XX:+UseJVMCICompiler


### PR DESCRIPTION
Close #191 - Remove `-XX:+UseJVMCICompiler` from `.jvmopts`