### PR TITLE
extras v0.19.0

### DIFF
--- a/changelogs/0.19.0.md
+++ b/changelogs/0.19.0.md
@@ -1,0 +1,33 @@
+## [0.19.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone19) - 2022-09-07
+
+## New Features
+* [`extras-refinement`] Add `NonEmptyString` concatenation syntax (#208)
+  ```scala
+  import eu.timepit.refined.types.string.NonEmptyString
+  import extras.refinement.syntax.string._
+  
+  NonEmptyString("abc") ++ NonEmptyString("def")
+  // NonEmptyString("abcdef")
+  
+  val givenName = NonEmptyString("Kevin")
+  val surname = NonEmptyString("Lee")
+  val fullName = givenName ++ NonEmptyString(" ") ++ surname
+  // NonEmptyString("Kevin Lee")
+  ```
+* [`extras-refinement`] Add `all` syntax to refinement (#210)
+  ```scala
+  import extras.refinement.syntax.all._
+  ```
+  is equivalent to
+  ```scala
+  import extras.refinement.syntax.refinement._
+  import extras.refinement.syntax.string._
+  ```
+
+## Internal Housekeeping
+* Upgrade docs site to Docusaurus `2.0.0-rc.1` (#195)
+* Upgrade docs site to Docusaurus `2.0.1` (#206)
+* [docs] Add `Fira Code Nerd Font` and `CaskaydiaCove Nerd Font`, and use `FiraCode Nerd Font` for code blocks (#203)
+* Upgrade `hedgehog` to `0.9.0` (#199)
+* Replace lunr search with Algolia DocSearch (#193)
+* Remove `-XX:+UseJVMCICompiler` from `.jvmopts` (#191)


### PR DESCRIPTION
# extras v0.19.0
## [0.19.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone19) - 2022-09-07

## New Features
* [`extras-refinement`] Add `NonEmptyString` concatenation syntax (#208)
  ```scala
  import eu.timepit.refined.types.string.NonEmptyString
  import extras.refinement.syntax.string._
  
  NonEmptyString("abc") ++ NonEmptyString("def")
  // NonEmptyString("abcdef")
  
  val givenName = NonEmptyString("Kevin")
  val surname = NonEmptyString("Lee")
  val fullName = givenName ++ NonEmptyString(" ") ++ surname
  // NonEmptyString("Kevin Lee")
  ```
* [`extras-refinement`] Add `all` syntax to refinement (#210)
  ```scala
  import extras.refinement.syntax.all._
  ```
  is equivalent to
  ```scala
  import extras.refinement.syntax.refinement._
  import extras.refinement.syntax.string._
  ```

## Internal Housekeeping
* Upgrade docs site to Docusaurus `2.0.0-rc.1` (#195)
* Upgrade docs site to Docusaurus `2.0.1` (#206)
* [docs] Add `Fira Code Nerd Font` and `CaskaydiaCove Nerd Font`, and use `FiraCode Nerd Font` for code blocks (#203)
* Upgrade `hedgehog` to `0.9.0` (#199)
* Replace lunr search with Algolia DocSearch (#193)
* Remove `-XX:+UseJVMCICompiler` from `.jvmopts` (#191)
