### PR TITLE
extras v0.20.0

### DIFF
--- a/changelogs/0.20.0.md
+++ b/changelogs/0.20.0.md
@@ -1,0 +1,39 @@
+## [0.20.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone20) - 2022-10-01
+
+## Artifact Name Change
+* Rename `extras-hedgehog-cats-effect3` to `extras-hedgehog-ce3` (#215)
+
+## New Features
+* [`extras-hedgehog-ce3`] Add support for test returning `IO[Result]` (#216)
+* [`extras-hedgehog-ce3`] Rename `withIO` to `runIO` in `CatsEffectRunner` (#221)
+  ```scala
+  def testSomething: Property =
+  for {
+    n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+  } yield runIO { // withIO: (=> IO[Result]) => Result
+    // Manual implicit Ticker creation is no longer required.
+
+    val expected = n
+    val actual   = IO(n)
+
+    actual.map(_ ==== expected) // IO[Result]
+  }
+  ```
+* [`extras-hedgehog-ce3`] Add `withIO` with `implicit ticker =>` (#223)
+  ```scala
+  def testSomething: Property =
+  for {
+    n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+  } yield withIO { implicit ticker =>
+
+    val expected = n
+    val actual   = IO(n)
+
+    actual.completeAs(expected) // Result
+  }
+  ```
+
+## Internal Housekeeping
+* Bump Scala.js (#219)
+  * `sbt-scalajs` to `1.11.0`
+  * `sbt-scalajs-crossproject` to `1.2.0`


### PR DESCRIPTION
# extras v0.20.0
## [0.20.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone20) - 2022-10-01

## Artifact Name Change
* Rename `extras-hedgehog-cats-effect3` to `extras-hedgehog-ce3` (#215)

## New Features
* [`extras-hedgehog-ce3`] Add support for test returning `IO[Result]` (#216)
* [`extras-hedgehog-ce3`] Rename `withIO` to `runIO` in `CatsEffectRunner` (#221)
  ```scala
  def testSomething: Property =
  for {
    n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
  } yield runIO { // withIO: (=> IO[Result]) => Result
    // Manual implicit Ticker creation is no longer required.

    val expected = n
    val actual   = IO(n)

    actual.map(_ ==== expected) // IO[Result]
  }
  ```
* [`extras-hedgehog-ce3`] Add `withIO` with `implicit ticker =>` (#223)
  ```scala
  def testSomething: Property =
  for {
    n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
  } yield withIO { implicit ticker =>

    val expected = n
    val actual   = IO(n)

    actual.completeAs(expected) // Result
  }
  ```

## Internal Housekeeping
* Bump Scala.js (#219)
  * `sbt-scalajs` to `1.11.0`
  * `sbt-scalajs-crossproject` to `1.2.0`
