### PR TITLE
extras v0.21.0

### DIFF
--- a/changelogs/0.21.0.md
+++ b/changelogs/0.21.0.md
@@ -1,0 +1,13 @@
+## [0.21.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone21) - 2022-10-17
+
+## Supported Scala Version
+* Drop support for Scala `2.11` (#236)
+
+
+## New Features
+* [`extras-core`] Add `Render[A]` type-class (#234)
+* [`extras-core`] Add syntax for `Render[A]` type-class (#238)
+
+
+## Internal Housekeeping
+* Add `sbt-dependency-submission` GitHub workflow (#231)


### PR DESCRIPTION
# extras v0.21.0
## [0.21.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone21) - 2022-10-17

## Supported Scala Version
* Drop support for Scala `2.11` (#236)


## New Features
* [`extras-core`] Add `Render[A]` type-class (#234)
* [`extras-core`] Add syntax for `Render[A]` type-class (#238)


## Internal Housekeeping
* Add `sbt-dependency-submission` GitHub workflow (#231)
