### PR TITLE
extras v0.21.1

### DIFF
--- a/changelogs/0.21.1.md
+++ b/changelogs/0.21.1.md
@@ -1,0 +1,4 @@
+## [0.21.1](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone22) - 2022-10-19
+
+## Fixed
+* Fix `Iterable[A].renderString` renders only the first element (#243)


### PR DESCRIPTION
# extras v0.21.1
## [0.21.1](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone22) - 2022-10-19

## Fixed
* Fix `Iterable[A].renderString` renders only the first element (#243)
