### PR TITLE
extras v0.22.0

### DIFF
--- a/changelogs/0.22.0.md
+++ b/changelogs/0.22.0.md
@@ -1,0 +1,4 @@
+## [0.22.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone23) - 2022-10-20
+
+## New Module
+* Modularise `extras-render` (#248)


### PR DESCRIPTION
# extras v0.22.0
## [0.22.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone23) - 2022-10-20

## New Module
* Modularise `extras-render` (#248)
