### PR TITLE
extras v0.23.0

### DIFF
--- a/changelogs/0.23.0.md
+++ b/changelogs/0.23.0.md
@@ -1,0 +1,39 @@
+## [0.23.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone24) - 2022-10-22
+
+## Package Rename
+* Rename `extras.render.syntax.render` => `extras.render.syntax` (#252)
+
+## New Features
+* [`extras-render`] Add `String` interpolation support for `Render` (#253)
+  ```scala
+  import extras.render.Render
+  import extras.render.syntax._
+  
+  final case class Foo(id: Int, name: String)
+  
+  object Foo {
+    implicit val fooRender: Render[Foo] =
+      foo => s"{ID=${foo.id.toString},Name=${foo.name}}"
+  }
+  
+  val foo1 = Foo(1, "A")
+  val foo2 = Foo(2, "B")
+  val foo3 = Foo(3, "C")
+  
+  println(render"$foo1 > $foo2 >> $foo3")
+  // {ID=1,Name=A} > {ID=2,Name=B} >> {ID=3,Name=C}
+  ```
+* [`extras-render`] Add `Render.render[A](A => String): Render[A]` (#256)
+  ```scala
+  import extras.render.Render
+  
+  final case class Something(value: String)
+  object Something {
+    implicit val renderSomething: Render[Something] =
+      Render.render(s => s"value=${s.value}")
+  }
+  
+  val foo = Something("Blah")
+  Render[Something].render(foo)
+  // String = "value=Blah"
+  ```


### PR DESCRIPTION
# extras v0.23.0
## [0.23.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone24) - 2022-10-22

## Package Rename
* Rename `extras.render.syntax.render` => `extras.render.syntax` (#252)

## New Features
* [`extras-render`] Add `String` interpolation support for `Render` (#253)
  ```scala
  import extras.render.Render
  import extras.render.syntax._
  
  final case class Foo(id: Int, name: String)
  
  object Foo {
    implicit val fooRender: Render[Foo] =
      foo => s"{ID=${foo.id.toString},Name=${foo.name}}"
  }
  
  val foo1 = Foo(1, "A")
  val foo2 = Foo(2, "B")
  val foo3 = Foo(3, "C")
  
  println(render"$foo1 > $foo2 >> $foo3")
  // {ID=1,Name=A} > {ID=2,Name=B} >> {ID=3,Name=C}
  ```
* [`extras-render`] Add `Render.render[A](A => String): Render[A]` (#256)
  ```scala
  import extras.render.Render
  
  final case class Something(value: String)
  object Something {
    implicit val renderSomething: Render[Something] =
      Render.render(s => s"value=${s.value}")
  }
  
  val foo = Something("Blah")
  Render[Something].render(foo)
  // String = "value=Blah"
  ```
