### PR TITLE
Fix #264 - extras.typeinfo.syntax.tags => extras.typeinfo.syntax.types (tags was the wrong name)

### DIFF
--- a/modules/extras-type-info/shared/src/main/scala-2/extras/typeinfo/syntax/types.scala
+++ b/modules/extras-type-info/shared/src/main/scala-2/extras/typeinfo/syntax/types.scala
@@ -8,7 +8,7 @@ import scala.reflect.runtime.universe._
 /** @author Kevin Lee
   * @since 2022-03-19
   */
-trait tags {
+trait types {
 
   implicit def weakTypeTagSyntax[A](weakTypeTag: WeakTypeTag[A]): WeakTypeTagSyntax[A] =
     new WeakTypeTagSyntax[A](weakTypeTag)
@@ -19,7 +19,7 @@ trait tags {
 
 }
 
-object tags extends types {
+object types extends types {
 
   final class WeakTypeTagSyntax[A](private val weakTypeTag: WeakTypeTag[A]) extends AnyVal {
     def nestedTypeName: String = {

--- a/modules/extras-type-info/shared/src/test/scala-2/extras/typeinfo/syntax/typesSpec.scala
+++ b/modules/extras-type-info/shared/src/test/scala-2/extras/typeinfo/syntax/typesSpec.scala
@@ -8,12 +8,12 @@ import scala.reflect.ClassTag
 /** @author Kevin Lee
   * @since 2022-03-14
   */
-object tagsSpec extends Properties {
+object typesSpec extends Properties {
   override def tests: List[Test] = List(
     example("test A.nestedTypeName[WeakTypeTag[A]]", testANestedTypeNameWeakTypeTagA),
     example("test weakTypeTag[A].nestedTypeName", testWeakTypeTagANestedTypeName),
     example("test (A with ClassTag[A]).nestedTypeName", testAWithClassTagANestedTypeName),
-    example("test ClassTag[A].nestedTypeName", testClassTagANestedTypeName)
+    example("test ClassTag[A].nestedTypeName", testClassTagANestedTypeName),
   )
 
   def testANestedTypeNameWeakTypeTagA: Result = {
@@ -38,7 +38,7 @@ object tagsSpec extends Properties {
         (actual2t ==== expected2t).log("Failed actual2t ==== expected2t"),
         (actual2 ==== expected2).log("Failed actual2 ==== expected2"),
         (actual3 ==== expected3).log("Failed actual3 ==== expected3"),
-        (actual4 ==== expected4).log("Failed actual4 ==== expected4")
+        (actual4 ==== expected4).log("Failed actual4 ==== expected4"),
       )
     )
   }
@@ -61,7 +61,7 @@ object tagsSpec extends Properties {
         actual1 ==== expected1,
         actual2 ==== expected2,
         actual3 ==== expected3,
-        actual4 ==== expected4
+        actual4 ==== expected4,
       )
     )
   }
@@ -82,7 +82,7 @@ object tagsSpec extends Properties {
         actual1 ==== expected1,
         actual2 ==== expected2,
         actual3 ==== expected3,
-        actual4 ==== expected4
+        actual4 ==== expected4,
       )
     )
   }
@@ -119,7 +119,7 @@ object tagsSpec extends Properties {
         actual1Data ==== expected1Data,
         actual2Data ==== expected2Data,
         actual3Data ==== expected3Data,
-        actual4Data ==== expected4Data
+        actual4Data ==== expected4Data,
       )
     )
   }


### PR DESCRIPTION
Fix #264 - `extras.typeinfo.syntax.tags` => `extras.typeinfo.syntax.types` (tags was the wrong name)