### PR TITLE
Close #270 - [`extras-hedgehog-circe`] Use `extras-type-info` to support Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -194,18 +194,19 @@ lazy val extrasCatsJs  = extrasCats.js.settings(Test / fork := false)
 
 lazy val extrasHedgehogCirce    = crossSubProject("hedgehog-circe", crossProject(JVMPlatform, JSPlatform))
   .settings(
-    crossScalaVersions := props.Scala2Versions,
+    crossScalaVersions := props.CrossScalaVersions,
     libraryDependencies ++= List(
       libs.cats,
       libs.hedgehogCore,
       libs.circeCore,
       libs.circeParser,
-      libs.kittens      % Test,
+//      libs.kittens      % Test,
       libs.circeGeneric % Test,
-    )
+    ),
+    libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
   )
   .dependsOn(
-    extrasReflects
+    extrasTypeInfo
   )
 lazy val extrasHedgehogCirceJvm = extrasHedgehogCirce.jvm
 lazy val extrasHedgehogCirceJs  = extrasHedgehogCirce.js.settings(Test / fork := false)

--- a/modules/extras-hedgehog-circe/shared/src/main/scala-2/extras/hedgehog/circe/RoundTripTester.scala
+++ b/modules/extras-hedgehog-circe/shared/src/main/scala-2/extras/hedgehog/circe/RoundTripTester.scala
@@ -1,0 +1,89 @@
+package extras.hedgehog.circe
+
+import cats.Show
+import cats.syntax.all._
+import extras.typeinfo.syntax.types._
+import hedgehog._
+import io.circe
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json, Printer}
+
+import scala.reflect.runtime.universe._
+
+/** @author Kevin Lee
+  * @since 2022-10-23
+  */
+object RoundTripTester {
+
+  def roundTripTest[A: Encoder: Decoder: Show: WeakTypeTag](a: A, indent: Int): Result = indent match {
+    case 0 =>
+      roundTripTest0(a, Printer.noSpaces)
+    case 2 =>
+      roundTripTest0(a, Printer.spaces2)
+    case 4 =>
+      roundTripTest0(a, Printer.spaces4)
+    case _ =>
+      roundTripTest0(a, Printer.indented(" " * indent))
+  }
+
+  private def roundTripTest0[A: Encoder: Decoder: Show: WeakTypeTag](a: A, printer: Printer): Result = {
+    val expected = a
+    val json     = a.asJson
+
+    import io.circe.parser._
+    decode[A](json.noSpaces) match {
+      case Right(actual) =>
+        (actual ==== expected)
+          .log(failureAfterParseSuccessMessage[A](actual, a, json, printer))
+      case Left(err) =>
+        Result
+          .failure
+          .log(decodeFailureMessage[A](a, json, err, printer))
+    }
+  }
+
+  private[circe] def failureAfterParseSuccessMessage[A: Show](
+    actual: A,
+    input: A,
+    json: Json,
+    printer: Printer,
+  )(
+    implicit weakTypeTag: WeakTypeTag[A]
+  ): String =
+    s"""Round-trip test for ${weakTypeTag.nestedTypeName} failed:
+       |  The input ${weakTypeTag.nestedTypeName} object does not equal to
+       |  the one that was encoded from the input to JSON then decoded to have
+       |  the ${weakTypeTag.nestedTypeName} type object back.
+       |> ---
+       |> Input: ${input.show}
+       |> ---
+       |> Actual: ${actual.show}
+       |> ---
+       |> JSON: ${json.printWith(printer)}
+       |""".stripMargin
+
+  private[circe] def decodeFailureMessage[A: Show](a: A, json: Json, err: circe.Error, printer: Printer)(
+    implicit weakTypeTag: WeakTypeTag[A]
+  ): String =
+    s"""Round-trip test for ${weakTypeTag.nestedTypeName} failed with error:
+       |> Error: ${err.show}
+       |> ---
+       |> Input: ${a.show}
+       |> ---
+       |> JSON: ${json.printWith(printer)}
+       |>""".stripMargin
+
+  trait Builder[A] {
+    def indent(indent: Int): Builder[A]
+
+    def test(): Result
+  }
+  private final case class BuilderA[A: Encoder: Decoder: Show: WeakTypeTag](a: A, _indent: Int) extends Builder[A] {
+    def indent(indent: Int): Builder[A] = copy(_indent = indent)
+
+    def test(): Result = roundTripTest(a, _indent)
+  }
+
+  def apply[A: Encoder: Decoder: Show: WeakTypeTag](a: A): Builder[A] = BuilderA(a, 2)
+
+}

--- a/modules/extras-hedgehog-circe/shared/src/test/scala/extras/hedgehog/circe/RoundTripTesterSpec.scala
+++ b/modules/extras-hedgehog-circe/shared/src/test/scala/extras/hedgehog/circe/RoundTripTesterSpec.scala
@@ -1,7 +1,7 @@
 package extras.hedgehog.circe
 
 import cats.syntax.all._
-import cats.{Show, derived}
+import cats.Show
 import hedgehog._
 import hedgehog.runner._
 import io.circe.{Codec, Decoder, Encoder}
@@ -112,14 +112,20 @@ object RoundTripTesterSpec extends Properties {
 
   final case class Something(id: Int, name: String)
   object Something {
-    implicit val somethingShow: Show[Something] = derived.semiauto.show
+    implicit val somethingShow: Show[Something] =
+      something => s"Something(id = ${something.id.toString}, name = ${something.name})"
 
     implicit val somethingCodec: Codec[Something] = io.circe.generic.semiauto.deriveCodec
   }
 
   final case class SomethingWithCustomDecoding(id: Int, name: String)
   object SomethingWithCustomDecoding {
-    implicit val somethingWithDifferentDecoderShow: Show[SomethingWithCustomDecoding] = derived.semiauto.show
+    implicit val somethingWithDifferentDecoderShow: Show[SomethingWithCustomDecoding] =
+      somethingWithCustomDecoding =>
+        List(
+          s"id = ${somethingWithCustomDecoding.id.toString}",
+          s"name = ${somethingWithCustomDecoding.name}",
+        ).mkString("SomethingWithCustomDecoding(", ", ", ")")
 
     implicit val somethingWithDifferentDecoderEncoder: Encoder[SomethingWithCustomDecoding] =
       io.circe.generic.semiauto.deriveEncoder
@@ -135,7 +141,16 @@ object RoundTripTesterSpec extends Properties {
   final case class SomethingWithDecodeFailure(id: Int, name: String)
 
   object SomethingWithDecodeFailure {
-    implicit val somethingWithDecodeFailureShow: Show[SomethingWithDecodeFailure] = derived.semiauto.show
+    implicit val somethingWithDecodeFailureShow: Show[SomethingWithDecodeFailure] =
+      somethingWithDecodeFailure =>
+        List(
+          s"id = ${somethingWithDecodeFailure.id.toString}",
+          s"name = ${somethingWithDecodeFailure.name}",
+        ).mkString(
+          "SomethingWithDecodeFailure(",
+          ", ",
+          ")",
+        )
 
     implicit val somethingWithDecodeFailureEncoder: Encoder[SomethingWithDecodeFailure] =
       io.circe.generic.semiauto.deriveEncoder


### PR DESCRIPTION
Close #270 - [`extras-hedgehog-circe`] Use `extras-type-info` to support Scala 3
- Scala 2 version uses `extras-type-info` as well, but `extras-type-info` internally uses `WeakTypeTag` from `scala.reflect.runtime.universe` in `scala-reflect`, an additional reflection API library, to get the type info.
- Scala 3 version of `extras-type-info` uses `scala.reflect.ClassTag`, `scala.compiletime` and `scala.quoted` to get the type info.