### PR TITLE
extras v0.24.0

### DIFF
--- a/changelogs/0.24.0.md
+++ b/changelogs/0.24.0.md
@@ -1,0 +1,59 @@
+## [0.24.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone25) - 2022-11-20
+
+## New Features
+### extras-type-info
+* [`extras-type-info`] Add `extras-type-info` module to replace `extras-reflects` with Scala 3 support (#264)
+  ```scala
+  sealed trait Aaa
+  object Aaa {
+    final case class Bbb(n: Int) extends Aaa
+    case object Ccc extends Aaa
+  
+    def bbb(n: Int): Aaa = Bbb(n)
+    def ccc: Aaa         = Ccc
+  }
+  
+  final case class Something[A](a: A)
+  
+  Aaa.bbb(123).nestedClassName
+  // Aaa.Bbb
+  
+  Aaa.ccc.nestedTypeName
+  // Aaa.Ccc
+  ```
+
+### extras-hedgehog-circe
+* [`extras-hedgehog-circe`] Add `round-trip` test support for circe (#263)
+  ```scala
+  object SomethingSpec extends Properties {
+    override def tests: List[Test] = List(
+      property("round-trip test Codec[Something]", roundTripTestCodecSomething)
+    )
+  
+    def roundTripTestCodecSomething: Property =
+      for {
+        something <- genSomething.log("something")
+      } yield {
+        RoundTripTester(something)
+          .indent(2)
+          .test()
+      }
+      
+    def genSomething: Gen[Something] =
+      for {
+        id   <- Gen.int(Range.linear(1, 100))
+        name <- Gen.string(Gen.unicode, Range.linear(3, 20))
+      } yield Something(id, name)
+
+    final case class Something(id: Int, name: String)
+    object Something {
+      implicit val somethingShow: Show[Something] =
+      something => s"Something(id = ${something.id.toString}, name = ${something.name})"
+
+      implicit val somethingCodec: Codec[Something] = io.circe.generic.semiauto.deriveCodec
+    }
+  }
+  ```
+* [`extras-hedgehog-circe`] Use `extras-type-info` to support Scala 3 (#270)
+  * Scala 2 version uses `extras-type-info` as well, but `extras-type-info` internally uses `WeakTypeTag` from `scala.reflect.runtime.universe` in `scala-reflect`, an additional reflection API library, to get the type info.
+  * Scala 3 version of `extras-type-info` uses `scala.reflect.ClassTag`, `scala.compiletime` and `scala.quoted` to get the type info.


### PR DESCRIPTION
# extras v0.24.0
## [0.24.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone25) - 2022-11-20

## New Features
### extras-type-info
* [`extras-type-info`] Add `extras-type-info` module to replace `extras-reflects` with Scala 3 support (#264)
  ```scala
  sealed trait Aaa
  object Aaa {
    final case class Bbb(n: Int) extends Aaa
    case object Ccc extends Aaa
  
    def bbb(n: Int): Aaa = Bbb(n)
    def ccc: Aaa         = Ccc
  }
  
  final case class Something[A](a: A)
  
  Aaa.bbb(123).nestedClassName
  // Aaa.Bbb
  
  Aaa.ccc.nestedTypeName
  // Aaa.Ccc
  ```

### extras-hedgehog-circe
* [`extras-hedgehog-circe`] Add `round-trip` test support for circe (#263)
  ```scala
  object SomethingSpec extends Properties {
    override def tests: List[Test] = List(
      property("round-trip test Codec[Something]", roundTripTestCodecSomething)
    )
  
    def roundTripTestCodecSomething: Property =
      for {
        something <- genSomething.log("something")
      } yield {
        RoundTripTester(something)
          .indent(2)
          .test()
      }
      
    def genSomething: Gen[Something] =
      for {
        id   <- Gen.int(Range.linear(1, 100))
        name <- Gen.string(Gen.unicode, Range.linear(3, 20))
      } yield Something(id, name)

    final case class Something(id: Int, name: String)
    object Something {
      implicit val somethingShow: Show[Something] =
      something => s"Something(id = ${something.id.toString}, name = ${something.name})"

      implicit val somethingCodec: Codec[Something] = io.circe.generic.semiauto.deriveCodec
    }
  }
  ```
* [`extras-hedgehog-circe`] Use `extras-type-info` to support Scala 3 (#270)
  * Scala 2 version uses `extras-type-info` as well, but `extras-type-info` internally uses `WeakTypeTag` from `scala.reflect.runtime.universe` in `scala-reflect`, an additional reflection API library, to get the type info.
  * Scala 3 version of `extras-type-info` uses `scala.reflect.ClassTag`, `scala.compiletime` and `scala.quoted` to get the type info.