### PR TITLE
extras v0.25.0

### DIFF
--- a/changelogs/0.25.0.md
+++ b/changelogs/0.25.0.md
@@ -1,0 +1,24 @@
+## [0.25.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone26) - 2022-11-20
+
+## New Feature
+### extras-type-info
+* [`extras-type-info`] Release `extras-type-info` (#273)
+  ```scala
+  sealed trait Aaa
+  object Aaa {
+    final case class Bbb(n: Int) extends Aaa
+    case object Ccc extends Aaa
+  
+    def bbb(n: Int): Aaa = Bbb(n)
+    def ccc: Aaa         = Ccc
+  }
+  
+  final case class Something[A](a: A)
+  
+  Aaa.bbb(123).nestedClassName
+  // Aaa.Bbb
+  
+  Aaa.ccc.nestedTypeName
+  // Aaa.Ccc
+  ```
+It was supposed to be released in `0.24.0` but wasn't included by mistake.


### PR DESCRIPTION
# extras v0.25.0
## [0.25.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone26) - 2022-11-20

## New Feature
### extras-type-info
* [`extras-type-info`] Release `extras-type-info` (#273)
  ```scala
  sealed trait Aaa
  object Aaa {
    final case class Bbb(n: Int) extends Aaa
    case object Ccc extends Aaa
  
    def bbb(n: Int): Aaa = Bbb(n)
    def ccc: Aaa         = Ccc
  }
  
  final case class Something[A](a: A)
  
  Aaa.bbb(123).nestedClassName
  // Aaa.Bbb
  
  Aaa.ccc.nestedTypeName
  // Aaa.Ccc
  ```
It was supposed to be released in `0.24.0` but wasn't included by mistake.