### PR TITLE
extras v0.26.0

### DIFF
--- a/changelogs/0.26.0.md
+++ b/changelogs/0.26.0.md
@@ -1,0 +1,101 @@
+## [0.26.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone27) - 2022-12-05
+
+## New Feature
+
+* [`extras-render-refined`] Add `newtype` + `refined` support (#277)
+  ```scala
+  import eu.timepit.refined.types.string.NonEmptyString
+  import extras.render.Render
+  import io.estatico.newtype.macros.newtype
+  
+  import extras.render.refined._
+  
+  @newtype case class Name(value: NonEmptyString)
+  object Name {
+  implicit val nameRender: Render[Name] = deriving
+  }
+  ```
+  instead of
+  ```scala
+  @newtype case class Name(value: NonEmptyString)
+  object Name {
+    implicit val nameRender: Render[Name] = Render.render(_.value.value)
+  }
+  ```
+
+* [`extras-doobie-tools`] Add doobie tools to run SQL query (#283)
+  * `extras-doobie-tools-ce2`
+  * `extras-doobie-tools-ce3`
+  
+  This is meant to be used for testing.
+  
+    e.g.)
+  ```scala
+  DbTools.fetchSingleRow[F][Example](
+    sql"""
+      SELECT id, name, note
+        FROM db_tools_test.example
+    """
+  )(transactor) // F[Option[Example]]
+  ```
+  ***
+  ```scala
+  DbTools.fetchMultipleRows[F][Example](
+  sql"""
+    SELECT id, name, note
+      FROM db_tools_test.example
+    """
+  )(transactor) // F[List[Example]]
+  ```
+  ***
+  ```scala
+  DbTools.updateSingle[F](
+    sql"""
+      INSERT INTO db_tools_test.example (id, name, note) VALUES (${example.id}, ${example.name}, ${example.note})
+    """
+  )(transactor) // F[Int]
+  
+  ```
+  ***
+  ```scala
+  // val examples: List[Example] = ???
+  DbTools.updateMultiple[F][Example](
+    "INSERT INTO db_tools_test.example (id, name, note) VALUES (?, ?, ?)"
+  )(examples)(transactor) // F[Int]
+  ```
+  with
+  ```scala
+  implicit val writeExample: Write[Example] =
+    Write[(Int, String, String)].contramap(example =>
+      (example.id.value, example.name.value, example.note.value)
+    )
+  
+  implicit val readExample: Read[Example] =
+    Read[(Int, String, String)].map {
+      case (id, name, note) =>
+        Example(Example.Id(id), Example.Name(name), Example.Note(note))
+    }
+  ```
+  Or in Scala 3,
+  ```scala
+  given readExample: Read[Example] =
+    Read[(Int, String, String)].map {
+      case (id, name, note) =>
+        Example(Example.Id(id), Example.Name(name), Example.Note(note))
+    }
+  
+  given writeExample: Write[Example] =
+    Write[(Int, String, String)].contramap(example =>
+      (example.id.value, example.name.value, example.note.value)
+    )
+  ```
+
+## Scala + Library Version Up
+
+* Bump Scala / bump libraries (#284)
+  * Scala `2.12.13` => `2.12.17`
+  * Scala `2.13.6` => `2.13.10`
+  * Scala `3.0.0` => `3.1.3`
+  * Cats `2.6.1` and `2.7.0` => `2.8.0`
+  * Cats Effect `2.5.4` => `2.5.5`
+  * Cats Effect `3.2.9` => `3.3.14`


### PR DESCRIPTION
# extras v0.26.0
## [0.26.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone27) - 2022-12-05

## New Feature

* [`extras-render-refined`] Add `newtype` + `refined` support (#277)
  ```scala
  import eu.timepit.refined.types.string.NonEmptyString
  import extras.render.Render
  import io.estatico.newtype.macros.newtype
  
  import extras.render.refined._
  
  @newtype case class Name(value: NonEmptyString)
  object Name {
  implicit val nameRender: Render[Name] = deriving
  }
  ```
  instead of
  ```scala
  @newtype case class Name(value: NonEmptyString)
  object Name {
    implicit val nameRender: Render[Name] = Render.render(_.value.value)
  }
  ```

* [`extras-doobie-tools`] Add doobie tools to run SQL query (#283)
  * `extras-doobie-tools-ce2`
  * `extras-doobie-tools-ce3`
  
  This is meant to be used for testing.
  
    e.g.)
  ```scala
  DbTools.fetchSingleRow[F][Example](
    sql"""
      SELECT id, name, note
        FROM db_tools_test.example
    """
  )(transactor) // F[Option[Example]]
  ```
  ***
  ```scala
  DbTools.fetchMultipleRows[F][Example](
  sql"""
    SELECT id, name, note
      FROM db_tools_test.example
    """
  )(transactor) // F[List[Example]]
  ```
  ***
  ```scala
  DbTools.updateSingle[F](
    sql"""
      INSERT INTO db_tools_test.example (id, name, note) VALUES (${example.id}, ${example.name}, ${example.note})
    """
  )(transactor) // F[Int]
  
  ```
  ***
  ```scala
  // val examples: List[Example] = ???
  DbTools.updateMultiple[F][Example](
    "INSERT INTO db_tools_test.example (id, name, note) VALUES (?, ?, ?)"
  )(examples)(transactor) // F[Int]
  ```
  with
  ```scala
  implicit val writeExample: Write[Example] =
    Write[(Int, String, String)].contramap(example =>
      (example.id.value, example.name.value, example.note.value)
    )
  
  implicit val readExample: Read[Example] =
    Read[(Int, String, String)].map {
      case (id, name, note) =>
        Example(Example.Id(id), Example.Name(name), Example.Note(note))
    }
  ```
  Or in Scala 3,
  ```scala
  given readExample: Read[Example] =
    Read[(Int, String, String)].map {
      case (id, name, note) =>
        Example(Example.Id(id), Example.Name(name), Example.Note(note))
    }
  
  given writeExample: Write[Example] =
    Write[(Int, String, String)].contramap(example =>
      (example.id.value, example.name.value, example.note.value)
    )
  ```

## Scala + Library Version Up

* Bump Scala / bump libraries (#284)
  * Scala `2.12.13` => `2.12.17`
  * Scala `2.13.6` => `2.13.10`
  * Scala `3.0.0` => `3.1.3`
  * Cats `2.6.1` and `2.7.0` => `2.8.0`
  * Cats Effect `2.5.4` => `2.5.5`
  * Cats Effect `3.2.9` => `3.3.14`
