### PR TITLE
extras v0.27.0

### DIFF
--- a/changelogs/0.27.0.md
+++ b/changelogs/0.27.0.md
@@ -1,0 +1,57 @@
+## [0.27.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone28) - 2023-01-15
+
+## New Features
+
+* [`extras-circe`]: Add an extension method to circe `Encoder` to add more fields (#291)
+  ```scala
+  import io.circe._
+  import io.circe.generic.semiauto._
+  
+  final case class Something(n: Int) {
+    def name: String = "Blah"
+  }
+  object Something {
+    implicit val somethingEncoder: Encoder[Something] = deriveEncoder
+  }
+  
+  Something(1).asJson.spaces2
+  ```
+  results in
+  ```json
+  {
+    "n": 1
+  }
+  ```
+  There should be an easy way to add the `name` field to have JSON like
+  ```json
+  {
+    "n": 1,
+    "name": "Blah"
+  }
+  ```
+  For instance,
+  ```scala
+  import extras.circe.codecs.encoder._
+  
+  object Something {
+    implicit val somethingEncoder: Encoder[Something] =
+      deriveEncoder.withFields { something =>
+        List("name" -> something.name.asJson)
+      }
+  }
+  ```
+* [`extras-fs2-v2-text`][`extras-fs2-v3-text`]: Add fs2 syntax to compile `Stream[F, Byte]` to `F[String]` (#295)
+  ```scala
+  import fs2.Stream
+  import extras.fs2.text.syntax._
+  
+  val stream: Stream[F, Byte] = ...
+  stream.utf8String // F[String]
+  ```
+  ```scala
+  import org.http4s.Response
+  import extras.fs2.text.syntax._
+  
+  val response: Response[F] = ...
+  response.body.utf8String // F[String]
+  ```


### PR DESCRIPTION
# extras v0.27.0
## [0.27.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone28) - 2023-01-15

## New Features

* [`extras-circe`]: Add an extension method to circe `Encoder` to add more fields (#291)
  ```scala
  import io.circe._
  import io.circe.generic.semiauto._
  
  final case class Something(n: Int) {
    def name: String = "Blah"
  }
  object Something {
    implicit val somethingEncoder: Encoder[Something] = deriveEncoder
  }
  
  Something(1).asJson.spaces2
  ```
  results in
  ```json
  {
    "n": 1
  }
  ```
  There should be an easy way to add the `name` field to have JSON like
  ```json
  {
    "n": 1,
    "name": "Blah"
  }
  ```
  For instance,
  ```scala
  import extras.circe.codecs.encoder._
  
  object Something {
    implicit val somethingEncoder: Encoder[Something] =
      deriveEncoder.withFields { something =>
        List("name" -> something.name.asJson)
      }
  }
  ```
* [`extras-fs2-v2-text`][`extras-fs2-v3-text`]: Add fs2 syntax to compile `Stream[F, Byte]` to `F[String]` (#295)
  ```scala
  import fs2.Stream
  import extras.fs2.text.syntax._
  
  val stream: Stream[F, Byte] = ...
  stream.utf8String // F[String]
  ```
  ```scala
  import org.http4s.Response
  import extras.fs2.text.syntax._
  
  val response: Response[F] = ...
  response.body.utf8String // F[String]
  ```
