### PR TITLE
Close #304 - [extras-fs2-v2-text][extras-fs2-v3-text]: Replace the implicit param, Sync, for utf8String from extras.fs2.text.syntax with Compiler

### DIFF
--- a/modules/extras-fs2-v2-text/shared/src/main/scala-2/extras/fs2/text/syntax.scala
+++ b/modules/extras-fs2-v2-text/shared/src/main/scala-2/extras/fs2/text/syntax.scala
@@ -1,6 +1,6 @@
 package extras.fs2.text
 
-import cats.effect.Sync
+import fs2.Stream.Compiler
 import fs2.{text, Stream}
 
 /** @author Kevin Lee
@@ -9,7 +9,7 @@ import fs2.{text, Stream}
 object syntax {
 
   implicit class byteStreamOps[F[*]](private val byteStream: Stream[F, Byte]) {
-    def utf8String(implicit sync: Sync[F]): F[String] =
+    def utf8String(implicit compiler: Compiler[F, F]): F[String] =
       byteStream
         .through(text.utf8Decode)
         .through(text.lines)

--- a/modules/extras-fs2-v2-text/shared/src/main/scala-3/extras/fs2/text/syntax.scala
+++ b/modules/extras-fs2-v2-text/shared/src/main/scala-3/extras/fs2/text/syntax.scala
@@ -1,6 +1,6 @@
 package extras.fs2.text
 
-import cats.effect.Sync
+import fs2.Stream.Compiler
 import fs2.{text, Stream}
 
 /** @author Kevin Lee
@@ -8,7 +8,7 @@ import fs2.{text, Stream}
   */
 object syntax {
   extension [F[*]](byteStream: Stream[F, Byte]) {
-    def utf8String(using Sync[F]): F[String] =
+    def utf8String(using Compiler[F, F]): F[String] =
       byteStream
         .through(text.utf8Decode)
         .through(text.lines)

--- a/modules/extras-fs2-v2-text/shared/src/test/scala/extras/fs2/text/syntaxSpec.scala
+++ b/modules/extras-fs2-v2-text/shared/src/test/scala/extras/fs2/text/syntaxSpec.scala
@@ -1,9 +1,11 @@
 package extras.fs2.text
 
-import cats.effect.IO
+import cats.effect.{IO, Sync}
+import cats.syntax.all._
 import fs2.Stream
 import hedgehog._
 import hedgehog.runner._
+import org.http4s.dsl.Http4sDsl
 
 import java.nio.charset.StandardCharsets
 
@@ -11,7 +13,6 @@ import java.nio.charset.StandardCharsets
   * @since 2023-01-15
   */
 object syntaxSpec extends Properties {
-  type F[A] = IO[A]
 
   override def tests: List[Test] = List(
     property("test ByteStream to utf8String.string", testByteStreamToUtf8String),
@@ -24,27 +25,37 @@ object syntaxSpec extends Properties {
     for {
       s <- Gen.string(Gen.alphaNum, Range.linear(1, 1000)).log("s")
     } yield {
-      val stream = Stream[F, Byte](s.getBytes(StandardCharsets.UTF_8).toList: _*)
 
-      import extras.fs2.text.syntax._
-      val expected = s
-      stream
-        .utf8String
-        .map { actual =>
-          actual ==== expected
-        }
+      def test[F[*]: Sync]: F[Result] = {
+
+        val stream = Stream[F, Byte](s.getBytes(StandardCharsets.UTF_8).toList: _*)
+
+        import extras.fs2.text.syntax._
+        val expected = s
+        stream
+          .utf8String
+          .map { actual =>
+            actual ==== expected
+          }
+      }
+
+      test[IO]
         .unsafeRunSync()
     }
 
   def testEmptyByteStreamToUtf8String: Result = {
-    val stream: Stream[F, Byte] = Stream.empty
 
-    import extras.fs2.text.syntax._
-    stream
-      .utf8String
-      .map { actual =>
-        actual ==== ""
-      }
+    def test[F[*]: Sync]: F[Result] = {
+      val stream: Stream[F, Byte] = Stream.empty
+      import extras.fs2.text.syntax._
+      stream
+        .utf8String
+        .map { actual =>
+          actual ==== ""
+        }
+    }
+
+    test[IO]
       .unsafeRunSync()
   }
 
@@ -52,44 +63,55 @@ object syntaxSpec extends Properties {
     for {
       s <- Gen.string(Gen.alphaNum, Range.linear(1, 1000)).log("s")
     } yield {
-      import org.http4s.dsl.io._
-      Ok(s)
+
+      def test[F[*]: Sync](implicit dsl: Http4sDsl[F]): F[Result] = {
+        import dsl._
+        Ok(s)
+          .flatMap { response =>
+            import extras.fs2.text.syntax._
+            val expected = s
+            response
+              .body
+              .utf8String
+              .map { actual =>
+                Result.all(
+                  List(
+                    (Result.assert(response.status.isEntityAllowed)).log("entity should be allowed"),
+                    (actual ==== expected).log("actual should be equal to expected"),
+                  )
+                )
+              }
+
+          }
+      }
+
+      implicit val dsl: Http4sDsl[IO] = org.http4s.dsl.io
+      test[IO]
+        .unsafeRunSync()
+    }
+
+  def testEmptyResponseBodyToUtf8String: Result = {
+    def test[F[*]: Sync](implicit dsl: Http4sDsl[F]): F[Result] = {
+      import dsl._
+      Continue()
         .flatMap { response =>
           import extras.fs2.text.syntax._
-          val expected = s
           response
             .body
             .utf8String
             .map { actual =>
               Result.all(
                 List(
-                  (Result.assert(response.status.isEntityAllowed)).log("entity should be allowed"),
-                  (actual ==== expected).log("actual should be equal to expected"),
+                  Result.assert(!response.status.isEntityAllowed).log("entity should not be allowed"),
+                  (actual ==== "").log("actual should be empty"),
                 )
               )
             }
-
         }
-        .unsafeRunSync()
     }
 
-  def testEmptyResponseBodyToUtf8String: Result = {
-    import extras.fs2.text.syntax._
-    import org.http4s.dsl.io._
-    Continue()
-      .flatMap { response =>
-        response
-          .body
-          .utf8String
-          .map { actual =>
-            Result.all(
-              List(
-                Result.assert(!response.status.isEntityAllowed).log("entity should not be allowed"),
-                (actual ==== "").log("actual should be empty"),
-              )
-            )
-          }
-      }
+    implicit val dsl: Http4sDsl[IO] = org.http4s.dsl.io
+    test[IO]
       .unsafeRunSync()
   }
 

--- a/modules/extras-fs2-v3-text/shared/src/main/scala-2/extras/fs2/text/syntax.scala
+++ b/modules/extras-fs2-v3-text/shared/src/main/scala-2/extras/fs2/text/syntax.scala
@@ -1,7 +1,6 @@
 package extras.fs2.text
 
-import cats.effect.Sync
-import fs2.{text, Stream}
+import fs2.{text, Compiler, Stream}
 
 /** @author Kevin Lee
   * @since 2023-01-15
@@ -9,7 +8,7 @@ import fs2.{text, Stream}
 object syntax {
 
   implicit class byteStreamOps[F[*]](private val byteStream: Stream[F, Byte]) {
-    def utf8String(implicit sync: Sync[F]): F[String] =
+    def utf8String(implicit compiler: Compiler[F, F]): F[String] =
       byteStream
         .through(text.utf8.decode)
         .through(text.lines)

--- a/modules/extras-fs2-v3-text/shared/src/main/scala-3/extras/fs2/text/syntax.scala
+++ b/modules/extras-fs2-v3-text/shared/src/main/scala-3/extras/fs2/text/syntax.scala
@@ -1,14 +1,13 @@
 package extras.fs2.text
 
-import cats.effect.Sync
-import fs2.{text, Stream}
+import fs2.{text, Compiler, Stream}
 
 /** @author Kevin Lee
   * @since 2023-01-15
   */
 object syntax {
   extension [F[*]](byteStream: Stream[F, Byte]) {
-    def utf8String(using Sync[F]): F[String] =
+    def utf8String(using Compiler[F, F]): F[String] =
       byteStream
         .through(text.utf8.decode)
         .through(text.lines)

--- a/modules/extras-fs2-v3-text/shared/src/test/scala/extras/fs2/text/syntaxSpec.scala
+++ b/modules/extras-fs2-v3-text/shared/src/test/scala/extras/fs2/text/syntaxSpec.scala
@@ -1,10 +1,13 @@
 package extras.fs2.text
 
-import cats.effect.IO
+import cats.effect.kernel.Concurrent
+import cats.effect.{IO, Sync}
+import cats.syntax.all._
 import extras.hedgehog.ce3.syntax.runner._
 import fs2.Stream
 import hedgehog._
 import hedgehog.runner._
+import org.http4s.dsl.Http4sDsl
 
 import java.nio.charset.StandardCharsets
 
@@ -12,7 +15,6 @@ import java.nio.charset.StandardCharsets
   * @since 2023-01-15
   */
 object syntaxSpec extends Properties {
-  type F[A] = IO[A]
 
   override def tests: List[Test] = List(
     property("test ByteStream to utf8String.string", testByteStreamToUtf8String),
@@ -25,71 +27,168 @@ object syntaxSpec extends Properties {
     for {
       s <- Gen.string(Gen.alphaNum, Range.linear(1, 1000)).log("s")
     } yield runIO {
-      val stream = Stream[F, Byte](s.getBytes(StandardCharsets.UTF_8).toList: _*)
 
-      import extras.fs2.text.syntax._
-      val expected = s
-      stream
-        .utf8String
-        .map { actual =>
-          actual ==== expected
-        }
+      def test[F[*]: Sync]: F[Result] = {
+        val stream = Stream[F, Byte](s.getBytes(StandardCharsets.UTF_8).toList: _*)
+
+        import extras.fs2.text.syntax._
+        val expected = s
+        stream
+          .utf8String
+          .map { actual =>
+            actual ==== expected
+          }
+      }
+
+      def test2[F[*]: Concurrent]: F[Result] = {
+        val stream = Stream[F, Byte](s.getBytes(StandardCharsets.UTF_8).toList: _*)
+
+        import extras.fs2.text.syntax._
+        val expected = s
+        stream
+          .utf8String
+          .map { actual =>
+            actual ==== expected
+          }
+      }
+
+      for {
+        result1 <- test[IO]
+        result2 <- test2[IO]
+      } yield Result.all(
+        List(
+          result1,
+          result2,
+        )
+      )
+
     }
 
   def testEmptyByteStreamToUtf8String: Result =
     runIO {
-      val stream: Stream[F, Byte] = Stream.empty
 
-      import extras.fs2.text.syntax._
-      stream
-        .utf8String
-        .map { actual =>
-          actual ==== ""
-        }
+      def test[F[*]: Sync]: F[Result] = {
+        val stream: Stream[F, Byte] = Stream.empty
+
+        import extras.fs2.text.syntax._
+        stream
+          .utf8String
+          .map { actual =>
+            actual ==== ""
+          }
+      }
+      test[IO]
     }
 
   def testResponseBodyToUtf8String: Property =
     for {
       s <- Gen.string(Gen.alphaNum, Range.linear(1, 1000)).log("s")
     } yield runIO {
-      import org.http4s.dsl.io._
-      Ok(s)
-        .flatMap { response =>
-          import extras.fs2.text.syntax._
-          val expected = s
-          response
-            .body
-            .utf8String
-            .map { actual =>
-              Result.all(
-                List(
-                  (Result.assert(response.status.isEntityAllowed)).log("entity should be allowed"),
-                  (actual ==== expected).log("actual should be equal to expected"),
+      def test[F[*]: Sync](implicit dsl: Http4sDsl[F]): F[Result]        = {
+        import dsl._
+        Ok(s)
+          .flatMap { response =>
+            import extras.fs2.text.syntax._
+            val expected = s
+            response
+              .body
+              .utf8String
+              .map { actual =>
+                Result.all(
+                  List(
+                    (Result.assert(response.status.isEntityAllowed)).log("entity should be allowed"),
+                    (actual ==== expected).log("actual should be equal to expected"),
+                  )
                 )
-              )
-            }
+              }
 
-        }
+          }
+      }
+      def test2[F[*]: Concurrent](implicit dsl: Http4sDsl[F]): F[Result] = {
+        import dsl._
+        Ok(s)
+          .flatMap { response =>
+            import extras.fs2.text.syntax._
+            val expected = s
+            response
+              .body
+              .utf8String
+              .map { actual =>
+                Result.all(
+                  List(
+                    (Result.assert(response.status.isEntityAllowed)).log("entity should be allowed"),
+                    (actual ==== expected).log("actual should be equal to expected"),
+                  )
+                )
+              }
+
+          }
+      }
+
+      implicit val dsl: Http4sDsl[IO] = org.http4s.dsl.io
+
+      for {
+        result1 <- test[IO]
+        result2 <- test2[IO]
+      } yield Result.all(
+        List(
+          result1,
+          result2,
+        )
+      )
     }
 
   def testEmptyResponseBodyToUtf8String: Result =
     runIO {
-      import extras.fs2.text.syntax._
-      import org.http4s.dsl.io._
-      Continue()
-        .flatMap { response =>
-          response
-            .body
-            .utf8String
-            .map { actual =>
-              Result.all(
-                List(
-                  Result.assert(!response.status.isEntityAllowed).log("entity should not be allowed"),
-                  (actual ==== "").log("actual should be empty"),
+      def test[F[*]: Sync](implicit dsl: Http4sDsl[F]): F[Result] = {
+        import dsl._
+        Continue()
+          .flatMap { response =>
+            import extras.fs2.text.syntax._
+            response
+              .body
+              .utf8String
+              .map { actual =>
+                Result.all(
+                  List(
+                    Result.assert(!response.status.isEntityAllowed).log("entity should not be allowed"),
+                    (actual ==== "").log("actual should be empty"),
+                  )
                 )
-              )
-            }
-        }
+              }
+          }
+      }
+
+      def test2[F[*]: Concurrent](implicit dsl: Http4sDsl[F]): F[Result] = {
+        import dsl._
+        Continue()
+          .flatMap { response =>
+            import extras.fs2.text.syntax._
+            response
+              .body
+              .utf8String
+              .map { actual =>
+                Result.all(
+                  List(
+                    Result.assert(!response.status.isEntityAllowed).log("entity should not be allowed"),
+                    (actual ==== "").log("actual should be empty"),
+                  )
+                )
+              }
+          }
+      }
+
+      implicit val dsl: Http4sDsl[IO] = org.http4s.dsl.io
+
+      for {
+        result1 <- test[IO]
+        result2 <- test2[IO]
+      } yield Result.all(
+        List(
+          result1,
+          result2,
+        )
+      )
     }
 
 }


### PR DESCRIPTION
Close #304 - [`extras-fs2-v2-text`][`extras-fs2-v3-text`]: Replace the implicit param, `Sync`, for `utf8String` from `extras.fs2.text.syntax` with `Compiler`