### PR TITLE
extras v0.28.0

### DIFF
--- a/changelogs/0.28.0.md
+++ b/changelogs/0.28.0.md
@@ -1,0 +1,14 @@
+## [0.28.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone29) - 2023-01-25
+
+## Changes
+* [`extras-fs2-v2-text`][`extras-fs2-v3-text`]: Replace the implicit param, `Sync`, for `utf8String` from `extras.fs2.text.syntax` with `Compiler` (#304)
+  
+  So the following method 
+  ```scala
+  def utf8String(implicit sync: Sync[F]): F[String]
+  ```
+  has been changed to
+  ```scala
+  def utf8String(implicit compiler: Compiler[F, F]): F[String]
+  ```
+  fs2 v2: `fs2.Stream.Compiler` / fs2 v3: `fs2.Compiler`


### PR DESCRIPTION
# extras v0.28.0
## [0.28.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone29) - 2023-01-25

## Changes
* [`extras-fs2-v2-text`][`extras-fs2-v3-text`]: Replace the implicit param, `Sync`, for `utf8String` from `extras.fs2.text.syntax` with `Compiler` (#304)
  
  So the following method 
  ```scala
  def utf8String(implicit sync: Sync[F]): F[String]
  ```
  has been changed to
  ```scala
  def utf8String(implicit compiler: Compiler[F, F]): F[String]
  ```
  fs2 v2: `fs2.Stream.Compiler` / fs2 v3: `fs2.Compiler`
