### PR TITLE
extras v0.29.0

### DIFF
--- a/changelogs/0.29.0.md
+++ b/changelogs/0.29.0.md
@@ -1,0 +1,84 @@
+## [0.29.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone30) - 2023-02-11
+
+## New Feature
+* Add [`extras-testing-tools`] and [`extras-testing-tools-cats`] with tools to use stub (#307)
+### extras-testing-tools
+```scala
+import extras.testing.StubTools
+
+trait TestType {
+  def foo(n: Int): Int
+}
+
+object TestTypeStub {
+  def apply(f: => Option[Int => Int]): TestType = new TestType {
+    override def foo(n: Int): Int =
+      f.fold[Int](throw StubTools.missing)(_(n))
+  }
+}
+```
+If the stub function is missing, it will throw a `MissingStubException` saying where the missing stub is.
+For example,
+```scala
+TestTypeStub(None)
+```
+results in
+```
+>> Missing Stub implementation at
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:11)
+>>   ---
+>>   Details:
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:11)
+       at scala.Option.fold(Option.scala:263)
+       at extras.testing.TestTypeStub$$anon$1.foo(TestType.scala:11)
+       at extras.testing.StubToolsSpec$.$anonfun$testMissingMissingCase$2(StubToolsSpec.scala:33)
+       ...
+```
+
+### extras-testing-tools-cats
+```scala
+import cats._
+import cats.syntax.all._
+import extras.testing.StubToolsCats
+
+trait TestType[F[*]] {
+  def foo(n: Int): F[Int]
+  def bar(n: Int): F[Int]
+}
+
+object TestTypeStub {
+  def apply[F[*]: MonadThrow](f4Foo: => Option[Int => Int], f4Bar: => Option[Int => F[Int]]): TestType[F] =
+    new TestType[F] {
+
+      override def foo(n: Int): F[Int] =
+        StubToolsCats.stub(f4Foo).map(_(n))
+
+      override def bar(n: Int): F[Int] =
+        StubToolsCats.stub(f4Bar).flatMap(_(n))
+    }
+}
+```
+If the stub function is missing, it will be `F` containing `MissingStubException` saying where the missing stub is.
+
+For example, the following code
+```scala
+val testType = TestTypeStub[IO](none, f.some)
+
+testType.foo(n).attempt // Either[Throwable, Int]
+```
+results in `IO[Either[Throwable, Int]]` where `Either` is `Left(MissingStubException)` with the information like the following.
+```
+>> Missing Stub implementation at
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
+>>   ---
+>>   Details:
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
+       at cats.ApplicativeError.fromOption(ApplicativeError.scala:318)
+       at cats.ApplicativeError.fromOption$(ApplicativeError.scala:315)
+       at cats.effect.IOLowPriorityInstances$IOEffect.fromOption(IO.scala:865)
+       at extras.testing.StubToolsCats$StubToolsCatsPartiallyApplied$.$anonfun$apply$1(StubToolsCats.scala:24)
+       ...
+```
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta5` (#310)


### PR DESCRIPTION
# extras v0.29.0
## [0.29.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone30) - 2023-02-11

## New Feature
* Add [`extras-testing-tools`] and [`extras-testing-tools-cats`] with tools to use stub (#307)
### extras-testing-tools
```scala
import extras.testing.StubTools

trait TestType {
  def foo(n: Int): Int
}

object TestTypeStub {
  def apply(f: => Option[Int => Int]): TestType = new TestType {
    override def foo(n: Int): Int =
      f.fold[Int](throw StubTools.missing)(_(n))
  }
}
```
If the stub function is missing, it will throw a `MissingStubException` saying where the missing stub is.
For example,
```scala
TestTypeStub(None)
```
results in
```
>> Missing Stub implementation at
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:11)
>>   ---
>>   Details:
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:11)
       at scala.Option.fold(Option.scala:263)
       at extras.testing.TestTypeStub$$anon$1.foo(TestType.scala:11)
       at extras.testing.StubToolsSpec$.$anonfun$testMissingMissingCase$2(StubToolsSpec.scala:33)
       ...
```

### extras-testing-tools-cats
```scala
import cats._
import cats.syntax.all._
import extras.testing.StubToolsCats

trait TestType[F[*]] {
  def foo(n: Int): F[Int]
  def bar(n: Int): F[Int]
}

object TestTypeStub {
  def apply[F[*]: MonadThrow](f4Foo: => Option[Int => Int], f4Bar: => Option[Int => F[Int]]): TestType[F] =
    new TestType[F] {

      override def foo(n: Int): F[Int] =
        StubToolsCats.stub(f4Foo).map(_(n))

      override def bar(n: Int): F[Int] =
        StubToolsCats.stub(f4Bar).flatMap(_(n))
    }
}
```
If the stub function is missing, it will be `F` containing `MissingStubException` saying where the missing stub is.

For example, the following code
```scala
val testType = TestTypeStub[IO](none, f.some)

testType.foo(n).attempt // Either[Throwable, Int]
```
results in `IO[Either[Throwable, Int]]` where `Either` is `Left(MissingStubException)` with the information like the following.
```
>> Missing Stub implementation at
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
>>   ---
>>   Details:
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
       at cats.ApplicativeError.fromOption(ApplicativeError.scala:318)
       at cats.ApplicativeError.fromOption$(ApplicativeError.scala:315)
       at cats.effect.IOLowPriorityInstances$IOEffect.fromOption(IO.scala:865)
       at extras.testing.StubToolsCats$StubToolsCatsPartiallyApplied$.$anonfun$apply$1(StubToolsCats.scala:24)
       ...
```

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta5` (#310)
