### PR TITLE
Close #314 - Upgrade `effectie` to `2.0.0-beta6`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -888,7 +888,7 @@ lazy val props = new {
 
   val EmbeddedPostgresVersion = "2.0.1"
 
-  val EffectieVersion = "2.0.0-beta5"
+  val EffectieVersion = "2.0.0-beta6"
 
   val isScala3Incompatible: ModuleID => Boolean =
     m =>


### PR DESCRIPTION
Close #314 - Upgrade `effectie` to `2.0.0-beta6`