### PR TITLE
extras v0.30.0

### DIFF
--- a/changelogs/0.30.0.md
+++ b/changelogs/0.30.0.md
@@ -1,0 +1,4 @@
+## [0.30.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone31) - 2023-02-12
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta6` (#314)


### PR DESCRIPTION
# extras v0.30.0
## [0.30.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone31) - 2023-02-12

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta6` (#314)
