### PR TITLE
Update: docs - fix incorrect module names

### DIFF
--- a/docs/common/intro.md
+++ b/docs/common/intro.md
@@ -72,10 +72,10 @@ Show [**all `extras` versions
   ```
 * extras-testing-tools
   ```scala
-  "io.kevinlee" %% "extras-testing" % "@VERSION@"
+  "io.kevinlee" %% "extras-testing-tools" % "@VERSION@"
   ```
   ```scala
-  "io.kevinlee" %% "extras-testing-cats" % "@VERSION@"
+  "io.kevinlee" %% "extras-testing-tools-cats" % "@VERSION@"
   ```
 * [extras-concurrent](extras-concurrent)
   ```scala


### PR DESCRIPTION
Update: docs - fix incorrect module names