### PR TITLE
extras v0.31.0

### DIFF
--- a/changelogs/0.31.0.md
+++ b/changelogs/0.31.0.md
@@ -1,0 +1,73 @@
+## [0.31.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone32) - 2023-02-15
+
+## New Feature
+* Add `extras-testing-tools-effectie` with `StubToolsFx` (#319)
+### extras-testing-tools-effectie
+```scala
+import cats._
+import effectie.core._
+
+trait TestType[F[*]] {
+  def foo(n: Int): F[Int]
+  def bar(n: Int): F[Int]
+}
+
+object TestTypeStub {
+  def apply[F[*]: Fx: Monad](f4Foo: => Option[Int => Int], f4Bar: => Option[Int => F[Int]]): TestType[F] =
+    new TestType[F] {
+
+      override def foo(n: Int): F[Int] =
+        StubToolsFx.stub(f4Foo).map(_(n))
+
+      override def bar(n: Int): F[Int] =
+        StubToolsFx.stub(f4Bar).flatMap(_(n))
+    }
+}
+```
+If the stub function is missing, it will be `F` containing `MissingStubException` saying where the missing stub is.
+
+For example, the following code
+```scala
+import effectie.instances.ce2.fx._
+
+val testType = TestTypeStub[IO](none, f.some)
+
+testType.foo(n).catchNonFatalThrowable // IO[Either[Throwable, Int]]
+```
+results in `IO[Either[Throwable, Int]]` where `Either` is `Left(MissingStubException)` with the information like the following.
+```
+>> Missing Stub implementation at
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
+>>   ---
+>>   Details:
+>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
+       at cats.ApplicativeError.fromOption(ApplicativeError.scala:318)
+       at cats.ApplicativeError.fromOption$(ApplicativeError.scala:315)
+       at cats.effect.IOLowPriorityInstances$IOEffect.fromOption(IO.scala:865)
+       at extras.testing.StubToolsFx$StubToolsFxPartiallyApplied$.$anonfun$apply$1(StubToolsFx.scala:24)
+       at cats.effect.internals.IORunLoop$.step(IORunLoop.scala:319)
+       at cats.effect.IO.unsafeRunTimed(IO.scala:338)
+       at cats.effect.IO.unsafeRunSync(IO.scala:256)
+       at extras.testing.StubToolsFxSpec$.$anonfun$testStubIntToIntWithIOFailureCase$1(StubToolsFxSpec.scala:79)
+       at extras.testing.StubToolsFxSpec$.$anonfun$testStubIntToIntWithIOFailureCase$1$adapted(StubToolsFxSpec.scala:71)
+       at scala.Option.map(Option.scala:242)
+       at hedgehog.core.PropertyT.$anonfun$map$1(PropertyT.scala:64)
+       at scala.Option.map(Option.scala:242)
+       at hedgehog.core.GenT.$anonfun$map$2(GenT.scala:12)
+       at hedgehog.core.TreeImplicits1$$anon$1.map(Tree.scala:35)
+       at hedgehog.core.TreeImplicits1$$anon$1.map(Tree.scala:33)
+       at hedgehog.core.Tree.map(Tree.scala:16)
+       at hedgehog.core.GenT.$anonfun$map$1(GenT.scala:12)
+       at hedgehog.core.PropertyTReporting.loop$1(PropertyT.scala:205)
+       at hedgehog.core.PropertyTReporting.report(PropertyT.scala:231)
+       at hedgehog.core.PropertyTReporting.report$(PropertyT.scala:182)
+       at hedgehog.package$$anon$2.report(package.scala:32)
+       at hedgehog.PropertyTOps.check(Property.scala:38)
+       at hedgehog.PropertyTOps.check$(Property.scala:37)
+       at hedgehog.package$Property$.check(package.scala:19)
+       at hedgehog.runner.Properties.$anonfun$main$1(Properties.scala:19)
+       at hedgehog.runner.Properties.$anonfun$main$1$adapted(Properties.scala:18)
+       at scala.collection.immutable.List.foreach(List.scala:333)
+       at hedgehog.runner.Properties.main(Properties.scala:18)
+       at extras.testing.StubToolsFxSpec.main(StubToolsFxSpec.scala)
+```


### PR DESCRIPTION
# extras v0.31.0
## [0.31.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone32) - 2023-02-15

## New Feature
* Add `extras-testing-tools-effectie` with `StubToolsFx` (#319)
### extras-testing-tools-effectie
```scala
import cats._
import effectie.core._

trait TestType[F[*]] {
  def foo(n: Int): F[Int]
  def bar(n: Int): F[Int]
}

object TestTypeStub {
  def apply[F[*]: Fx: Monad](f4Foo: => Option[Int => Int], f4Bar: => Option[Int => F[Int]]): TestType[F] =
    new TestType[F] {

      override def foo(n: Int): F[Int] =
        StubToolsFx.stub(f4Foo).map(_(n))

      override def bar(n: Int): F[Int] =
        StubToolsFx.stub(f4Bar).flatMap(_(n))
    }
}
```
If the stub function is missing, it will be `F` containing `MissingStubException` saying where the missing stub is.

For example, the following code
```scala
import effectie.instances.ce2.fx._

val testType = TestTypeStub[IO](none, f.some)

testType.foo(n).catchNonFatalThrowable // IO[Either[Throwable, Int]]
```
results in `IO[Either[Throwable, Int]]` where `Either` is `Left(MissingStubException)` with the information like the following.
```
>> Missing Stub implementation at
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
>>   ---
>>   Details:
>>   extras.testing.TestTypeStub$$anon$1.$anonfun$foo$1(TestType.scala:16)
       at cats.ApplicativeError.fromOption(ApplicativeError.scala:318)
       at cats.ApplicativeError.fromOption$(ApplicativeError.scala:315)
       at cats.effect.IOLowPriorityInstances$IOEffect.fromOption(IO.scala:865)
       at extras.testing.StubToolsFx$StubToolsFxPartiallyApplied$.$anonfun$apply$1(StubToolsFx.scala:24)
       at cats.effect.internals.IORunLoop$.step(IORunLoop.scala:319)
       at cats.effect.IO.unsafeRunTimed(IO.scala:338)
       at cats.effect.IO.unsafeRunSync(IO.scala:256)
       at extras.testing.StubToolsFxSpec$.$anonfun$testStubIntToIntWithIOFailureCase$1(StubToolsFxSpec.scala:79)
       at extras.testing.StubToolsFxSpec$.$anonfun$testStubIntToIntWithIOFailureCase$1$adapted(StubToolsFxSpec.scala:71)
       at scala.Option.map(Option.scala:242)
       at hedgehog.core.PropertyT.$anonfun$map$1(PropertyT.scala:64)
       at scala.Option.map(Option.scala:242)
       at hedgehog.core.GenT.$anonfun$map$2(GenT.scala:12)
       at hedgehog.core.TreeImplicits1$$anon$1.map(Tree.scala:35)
       at hedgehog.core.TreeImplicits1$$anon$1.map(Tree.scala:33)
       at hedgehog.core.Tree.map(Tree.scala:16)
       at hedgehog.core.GenT.$anonfun$map$1(GenT.scala:12)
       at hedgehog.core.PropertyTReporting.loop$1(PropertyT.scala:205)
       at hedgehog.core.PropertyTReporting.report(PropertyT.scala:231)
       at hedgehog.core.PropertyTReporting.report$(PropertyT.scala:182)
       at hedgehog.package$$anon$2.report(package.scala:32)
       at hedgehog.PropertyTOps.check(Property.scala:38)
       at hedgehog.PropertyTOps.check$(Property.scala:37)
       at hedgehog.package$Property$.check(package.scala:19)
       at hedgehog.runner.Properties.$anonfun$main$1(Properties.scala:19)
       at hedgehog.runner.Properties.$anonfun$main$1$adapted(Properties.scala:18)
       at scala.collection.immutable.List.foreach(List.scala:333)
       at hedgehog.runner.Properties.main(Properties.scala:18)
       at extras.testing.StubToolsFxSpec.main(StubToolsFxSpec.scala)
```
