### PR TITLE
extras v0.32.0

### DIFF
--- a/changelogs/0.32.0.md
+++ b/changelogs/0.32.0.md
@@ -1,0 +1,12 @@
+## [0.32.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone33) - 2023-02-26
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta7` (#322)
+* Upgrade sbt-plugins (#324)
+  * `sbt-scalafmt` to `2.5.0`
+    * `scalafmt` to `3.7.2`
+  * `sbt-scoverage` to `2.0.7`
+  * `sbt-mdoc` to `2.3.7`
+  * `sbt-tpolecat` to `0.4.2`
+  * `scalafix-rules` to `0.2.15`
+  * `sbt-scalajs` to `1.13.0`


### PR DESCRIPTION
# extras v0.32.0
## [0.32.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone33) - 2023-02-26

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta7` (#322)
* Upgrade sbt-plugins (#324)
  * `sbt-scalafmt` to `2.5.0`
    * `scalafmt` to `3.7.2`
  * `sbt-scoverage` to `2.0.7`
  * `sbt-mdoc` to `2.3.7`
  * `sbt-tpolecat` to `0.4.2`
  * `scalafix-rules` to `0.2.15`
  * `sbt-scalajs` to `1.13.0`
