### PR TITLE
Close #331 - [`extras-circe`] Add `renameFields` for `Encoder` to rename circe `Json` fields

### DIFF
--- a/modules/extras-circe/shared/src/main/scala/extras/circe/codecs/encoder.scala
+++ b/modules/extras-circe/shared/src/main/scala/extras/circe/codecs/encoder.scala
@@ -14,12 +14,32 @@ object encoder extends encoder {
 
   class EncoderExtras[A](private val encoder: Encoder[A]) extends AnyVal {
     def withFields(newFields: A => List[(String, Json)]): Encoder[A] = EncoderExtras.withFields(encoder)(newFields)
+
+    def renameFields(newName: (String, String), rest: (String, String)*): Encoder[A] =
+      EncoderExtras.renameFields(encoder)(newName, rest: _*)
   }
+
   object EncoderExtras {
 
     def withFields[A](encoder: Encoder[A])(newFields: A => List[(String, Json)]): Encoder[A] =
       Encoder.instance[A] { a =>
         Json.obj(newFields(a): _*).deepMerge(encoder(a))
+      }
+
+    def renameFields[A](encoder: Encoder[A])(newName: (String, String), rest: (String, String)*): Encoder[A] =
+      Encoder.instance[A] { a =>
+        val originalJson = encoder(a)
+        originalJson.mapObject { jsObj =>
+          val namePairs = newName :: rest.toList
+          namePairs.foldLeft(jsObj) {
+            case (jsObj, (oldName, newName)) =>
+              jsObj(oldName)
+                .map { valueFound =>
+                  jsObj.add(newName, valueFound).remove(oldName)
+                }
+                .getOrElse(jsObj)
+          }
+        }
       }
   }
 }


### PR DESCRIPTION
Close #331 - [`extras-circe`] Add `renameFields` for `Encoder` to rename circe `Json` fields