### PR TITLE
Close #335 - [`extras-circe`] `renameFields` for `Encoder` should fail encoding when new name conflicts with the existing name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -833,6 +833,16 @@ def crossSubProject(projectName: String, crossProject: CrossProject.Builder): Cr
           ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
       ),
       wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.ImplicitConversion, Wart.ImplicitParameter),
+      Compile / console / scalacOptions :=
+        (console / scalacOptions)
+          .value
+          .filterNot(option => option.contains("wartremover") || option.contains("import")),
+      //      Test / console / wartremoverErrors      := List.empty,
+      //      Test / console / wartremoverWarnings    := List.empty,
+      Test / console / scalacOptions :=
+        (console / scalacOptions)
+          .value
+          .filterNot(option => option.contains("wartremover") || option.contains("import")),
       scalacOptions := {
         val options = scalacOptions.value
         if (isScala3(scalaVersion.value)) {

--- a/modules/extras-circe/shared/src/main/scala/extras/circe/codecs/encoder.scala
+++ b/modules/extras-circe/shared/src/main/scala/extras/circe/codecs/encoder.scala
@@ -1,6 +1,9 @@
 package extras.circe.codecs
 
+import cats.syntax.all._
 import io.circe.{Encoder, Json}
+
+import scala.reflect.ClassTag
 
 /** @author Kevin Lee
   * @since 2023-01-14
@@ -12,11 +15,11 @@ trait encoder {
 }
 object encoder extends encoder {
 
-  class EncoderExtras[A](private val encoder: Encoder[A]) extends AnyVal {
+  final class EncoderExtras[A](private val encoder: Encoder[A]) extends AnyVal {
     def withFields(newFields: A => List[(String, Json)]): Encoder[A] = EncoderExtras.withFields(encoder)(newFields)
 
-    def renameFields(newName: (String, String), rest: (String, String)*): Encoder[A] =
-      EncoderExtras.renameFields(encoder)(newName, rest: _*)
+    def renameFields(newName: (String, String), rest: (String, String)*)(implicit classTag: ClassTag[A]): Encoder[A] =
+      EncoderExtras.renameFields[A](encoder)(newName, rest: _*)
   }
 
   object EncoderExtras {
@@ -26,20 +29,41 @@ object encoder extends encoder {
         Json.obj(newFields(a): _*).deepMerge(encoder(a))
       }
 
-    def renameFields[A](encoder: Encoder[A])(newName: (String, String), rest: (String, String)*): Encoder[A] =
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    def renameFields[A: ClassTag](encoder: Encoder[A])(newName: (String, String), rest: (String, String)*): Encoder[A] =
       Encoder.instance[A] { a =>
         val originalJson = encoder(a)
         originalJson.mapObject { jsObj =>
           val namePairs = newName :: rest.toList
-          namePairs.foldLeft(jsObj) {
-            case (jsObj, (oldName, newName)) =>
-              jsObj(oldName)
-                .map { valueFound =>
-                  jsObj.add(newName, valueFound).remove(oldName)
-                }
-                .getOrElse(jsObj)
+          val names     = jsObj.keys.toList
+          val conflicts = namePairs.filter {
+            case (_, newName) =>
+              names.exists(_ === newName)
+          }
+          if (conflicts.nonEmpty) {
+            throw NamingConflictError(
+              conflicts.sorted,
+              implicitly[ClassTag[A]].runtimeClass.getName,
+            ) // scalafix:ok DisableSyntax.throw
+          } else {
+            namePairs.foldLeft(jsObj) {
+              case (jsObj, (oldName, newName)) =>
+                jsObj(oldName)
+                  .map { valueFound =>
+                    jsObj.add(newName, valueFound).remove(oldName)
+                  }
+                  .getOrElse(jsObj)
+            }
           }
         }
       }
   }
+
+  final case class NamingConflictError(names: List[(String, String)], typeName: String)
+      extends RuntimeException(
+        s"There are newName values conflict with the existing filed names for $typeName. " +
+          "conflicted newNames (oldName -> newName): " +
+          s"${names.map { case (oldName, newName) => s"$oldName -> $newName" }.mkString("[", ", ", "]")}"
+      )
+
 }


### PR DESCRIPTION
Close #335 - [`extras-circe`] `renameFields` for `Encoder` should fail encoding when new name conflicts with the existing name