### PR TITLE
extras v0.33.0

### DIFF
--- a/changelogs/0.33.0.md
+++ b/changelogs/0.33.0.md
@@ -1,0 +1,118 @@
+## [0.33.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone34) - 2023-03-06
+
+## New Features
+
+* [`extras-circe`] Add `renameFields` for `Encoder` to rename circe `Json` fields (#331)
+  ```scala
+  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
+  object Something {
+    import extras.circe.codecs.encoder._
+    implicit val somethingEncoder: Encoder[Something] =
+      deriveEncoder[Something].renameFields(
+        "a"  -> "productNumber",
+        "b"  -> "name",
+        "c" -> "inStock",
+      )
+  }
+  
+  import io.circe.syntax._
+  Something(1, "Vibranium Shield", BidDecimal(9999999), false).asJson.spaces2
+  ```
+  ```json
+  {
+    "id": 1,
+    "name": "Vibranium Shield",
+    "price": 9999999,
+    "inStock": false
+  }
+  ```
+  * [`extras-circe`] `renameFields` for `Encoder` should fail encoding when new name conflicts with the existing name (#335)
+    ```scala
+    final case class Something(n: Int, s: String, name: String)
+    object Something {
+    
+      import extras.circe.codecs.encoder._
+    
+      implicit val somethingEncoder: Encoder[Something] =
+        deriveEncoder[Something].renameFields(
+          "n" -> "productNumber",
+          "s" -> "name", // Something already has a field named "name"
+        )
+    }
+    
+    io.circe.syntax._
+    Something(1, "some name", "another name").asJson
+    // This fails with extras.circe.codecs.encoder.NamingConflictError
+    ```
+
+* [`extras-circe`] Add `renameFields` for `Decoder` to rename circe `Json` fields (#333)
+  ```scala
+  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
+  object Something {
+    import extras.circe.codecs.decoder._
+  
+    implicit val somethingDecoder: Decoder[Something] =
+      deriveDecoder[Something].renameFields(
+        "a" -> "productNumber",
+        "b" -> "name",
+        "c" -> "inStock",
+      )
+  }
+  ```
+  ```scala
+  val json = """{
+    "productNumber": 1,
+    "name": "Vibranium Shield",
+    "price": 9999999,
+    "inStock": false
+  }"""
+  
+  import io.circe.parser._
+  decode[Something](json)
+  // Either[Error, Something] = Right(Something(a = 1, b = "Vibranium Shield", price = 9999999, c = false))
+  ```
+
+* [`extras-circe`] Add `renameFields` for `Codec` to rename circe `Json` fields (#336)
+  ```scala
+  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
+  object Something {
+    import extras.circe.codecs.codec._
+    implicit val somethingEncoder: Codec[Something] =
+      deriveCodec[Something].renameFields(
+        "a"  -> "productNumber",
+        "b"  -> "name",
+        "c" -> "inStock",
+      )
+  }
+  
+  val something = Something(1, "Vibranium Shield", BidDecimal(9999999), false)
+  ```
+  Encoding:
+  ```scala
+  import io.circe.syntax._
+  something.asJson.spaces2
+  ```
+  ```json
+  {
+    "id": 1,
+    "name": "Vibranium Shield",
+    "price": 9999999,
+    "inStock": false
+  }
+  ```
+  Decoding:
+  ```scala
+  val json = """{
+    "productNumber": 1,
+    "name": "Vibranium Shield",
+    "price": 9999999,
+    "inStock": false
+  }"""
+  
+  import io.circe.parser._
+  decode[Something](json)
+  // Either[Error, Something] = Right(Something(a = 1, b = "Vibranium Shield", price = 9999999, c = false))
+  ```
+
+## Improvement
+* Optimize `StubToolsCats` and `StubToolsFx` (#329)


### PR DESCRIPTION
# extras v0.33.0
## [0.33.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone34) - 2023-03-06

## New Features

* [`extras-circe`] Add `renameFields` for `Encoder` to rename circe `Json` fields (#331)
  ```scala
  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
  object Something {
    import extras.circe.codecs.encoder._
    implicit val somethingEncoder: Encoder[Something] =
      deriveEncoder[Something].renameFields(
        "a"  -> "productNumber",
        "b"  -> "name",
        "c" -> "inStock",
      )
  }
  
  import io.circe.syntax._
  Something(1, "Vibranium Shield", BidDecimal(9999999), false).asJson.spaces2
  ```
  ```json
  {
    "id": 1,
    "name": "Vibranium Shield",
    "price": 9999999,
    "inStock": false
  }
  ```
  * [`extras-circe`] `renameFields` for `Encoder` should fail encoding when new name conflicts with the existing name (#335)
    ```scala
    final case class Something(n: Int, s: String, name: String)
    object Something {
    
      import extras.circe.codecs.encoder._
    
      implicit val somethingEncoder: Encoder[Something] =
        deriveEncoder[Something].renameFields(
          "n" -> "productNumber",
          "s" -> "name", // Something already has a field named "name"
        )
    }
    
    io.circe.syntax._
    Something(1, "some name", "another name").asJson
    // This fails with extras.circe.codecs.encoder.NamingConflictError
    ```

* [`extras-circe`] Add `renameFields` for `Decoder` to rename circe `Json` fields (#333)
  ```scala
  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
  object Something {
    import extras.circe.codecs.decoder._
  
    implicit val somethingDecoder: Decoder[Something] =
      deriveDecoder[Something].renameFields(
        "a" -> "productNumber",
        "b" -> "name",
        "c" -> "inStock",
      )
  }
  ```
  ```scala
  val json = """{
    "productNumber": 1,
    "name": "Vibranium Shield",
    "price": 9999999,
    "inStock": false
  }"""
  
  import io.circe.parser._
  decode[Something](json)
  // Either[Error, Something] = Right(Something(a = 1, b = "Vibranium Shield", price = 9999999, c = false))
  ```

* [`extras-circe`] Add `renameFields` for `Codec` to rename circe `Json` fields (#336)
  ```scala
  final case class Something(a: Int, b: String, price: BigDecimal, c: Boolean)
  object Something {
    import extras.circe.codecs.codec._
    implicit val somethingEncoder: Codec[Something] =
      deriveCodec[Something].renameFields(
        "a"  -> "productNumber",
        "b"  -> "name",
        "c" -> "inStock",
      )
  }
  
  val something = Something(1, "Vibranium Shield", BidDecimal(9999999), false)
  ```
  Encoding:
  ```scala
  import io.circe.syntax._
  something.asJson.spaces2
  ```
  ```json
  {
    "id": 1,
    "name": "Vibranium Shield",
    "price": 9999999,
    "inStock": false
  }
  ```
  Decoding:
  ```scala
  val json = """{
    "productNumber": 1,
    "name": "Vibranium Shield",
    "price": 9999999,
    "inStock": false
  }"""
  
  import io.circe.parser._
  decode[Something](json)
  // Either[Error, Something] = Right(Something(a = 1, b = "Vibranium Shield", price = 9999999, c = false))
  ```

## Improvement
* Optimize `StubToolsCats` and `StubToolsFx` (#329)
