### PR TITLE
Update: docs - with new extension methods to `Encoder`, `Decoder` and `Codec` in circe

### DIFF
--- a/docs/common/intro.md
+++ b/docs/common/intro.md
@@ -15,6 +15,7 @@ slug: '/'
 |--------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |             extras-render | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-render_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-render_2.13)                         |
 |               extras-cats | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-cats_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-cats_2.13)                             |
+|              extras-circe | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-circe_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-circe_2.13)                           |
 |           extras-scala-io | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-scala-io_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-scala-io_2.13)                     |
 |       extras-hedgehog-ce3 | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-hedgehog-ce3_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-hedgehog-ce3_2.13)             |
 |     extras-hedgehog-circe | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-hedgehog-circe_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-hedgehog-circe_2.13)         |
@@ -22,7 +23,6 @@ slug: '/'
 |         extras-refinement | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-refinement_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-refinement_2.13)                 |
 |         extras-concurrent | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-concurrent_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-concurrent_2.13)                 |
 | extras-concurrent-testing | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-concurrent-testing_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-concurrent-testing_2.13) |
-|           extras-reflects | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.kevinlee/extras-reflects_2.13/badge.svg)](https://search.maven.org/artifact/io.kevinlee/extras-reflects_2.13)                     |
 
 :::info
 Supported Scala Versions: @SUPPORTED_SCALA_VERSIONS@

--- a/docs/extras-circe/codecs-codec.md
+++ b/docs/extras-circe/codecs-codec.md
@@ -1,0 +1,221 @@
+---
+sidebar_position: 3
+id: 'codecs-codec'
+title: 'Codec'
+---
+
+There are extension methods for `Encoder`, `Decoder` and `Codec`.
+
+## Encoder[A].renameFields
+With `renameFields`, you can make the existing JSON `Encoder` to rename the existing fields.
+
+```scala
+import extras.circe.codecs.encoder._
+
+Encoder[A].renameFields (
+  "name1" -> "newName1",
+  "name2" -> "newName2"
+) // Encoder[A]
+```
+
+
+### Example
+
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.encoder._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  implicit val somethingEncoder: Encoder[Something] =
+    deriveEncoder[Something]
+      .renameFields(
+        "n" -> "id",
+        "s" -> "name"
+      )
+}
+
+val something = Something(1, "Vibranium Shield", BigDecimal(999999999))
+something.asJson
+something.asJson.spaces2
+```
+
+### Comparison
+Let's compare it with the `Encoder` without `withFields` syntax.
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.encoder._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  val originalSomethingEncoder: Encoder[Something] = deriveEncoder
+  implicit val somethingEncoder: Encoder[Something] = originalSomethingEncoder
+    .renameFields(
+      "n" -> "id",
+      "s" -> "name"
+    )
+}
+
+val something = Something(1, "Vibranium Shield", BigDecimal(999999999))
+
+Something.originalSomethingEncoder(something)
+Something.originalSomethingEncoder(something).spaces2
+
+something.asJson
+something.asJson.spaces2
+```
+
+
+## Decoder[A].renameFields
+With `renameFields`, you can make the existing JSON `Decoder` to rename the existing fields.
+
+```scala
+import extras.circe.codecs.encoder._
+
+Decoder[A].renameFields (
+  "name1" -> "newName1",
+  "name2" -> "newName2"
+) // Decoder[A]
+```
+
+
+### Example
+
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.decoder._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  implicit val somethingDecoder: Decoder[Something] =
+    deriveDecoder[Something]
+      .renameFields(
+        "n" -> "id",
+        "s" -> "name"
+      )
+}
+
+val jsonString =
+  """
+  {
+    "id": 1,
+    "name": "Vibranium Shield",
+    "price": 999999999
+  }
+  """ 
+
+import io.circe.parser._
+decode[Something](jsonString)
+```
+
+### Comparison
+Let's compare it with the `Encoder` without `withFields` syntax.
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.decoder._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  val originalSomethingDecoder: Decoder[Something] = deriveDecoder
+  implicit val somethingDecoder: Decoder[Something] =
+    originalSomethingDecoder
+      .renameFields(
+        "n" -> "id",
+        "s" -> "name"
+      )
+}
+
+val jsonString =
+  """
+  {
+    "id": 1,
+    "name": "Vibranium Shield",
+    "price": 999999999
+  }
+  """
+
+import io.circe.parser._
+decode[Something](jsonString)(Something.originalSomethingDecoder)
+
+decode[Something](jsonString)
+```
+
+## Codec[A].renameFields (Encoder +  Decoder)
+With `renameFields`, you can make the existing JSON `Codec` to rename the existing fields.
+
+```scala
+import extras.circe.codecs.codec._
+
+Codec[A].renameFields (
+  "name1" -> "newName1",
+  "name2" -> "newName2"
+) // Codec[A]
+```
+
+
+### Example
+
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.codec._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  implicit val somethingCodec: Codec[Something] =
+    deriveCodec[Something]
+      .renameFields(
+        "n" -> "id",
+        "s" -> "name"
+      )
+}
+
+val something = Something(1, "Vibranium Shield", BigDecimal(999999999))
+something.asJson
+val jsonString = something.asJson.spaces2
+
+import io.circe.parser._
+decode[Something](jsonString)
+```
+
+### Comparison
+Let's compare it with the `Encoder` without `withFields` syntax.
+```scala mdoc:reset-object
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import extras.circe.codecs.codec._
+
+final case class Something(n: Int, s: String, price: BigDecimal)
+object Something {
+  val originalSomethingCodec: Codec[Something] = deriveCodec
+  implicit val somethingCodec: Codec[Something] = originalSomethingCodec
+    .renameFields(
+      "n" -> "id",
+      "s" -> "name"
+    )
+}
+
+val something = Something(1, "Vibranium Shield", BigDecimal(999999999))
+
+Something.originalSomethingCodec(something)
+Something.originalSomethingCodec(something).spaces2
+
+something.asJson
+val jsonString = something.asJson.spaces2
+
+import io.circe.parser._
+decode[Something](jsonString)(Something.originalSomethingCodec)
+
+decode[Something](jsonString)
+```
+

--- a/docs/extras-circe/codecs-encoder.md
+++ b/docs/extras-circe/codecs-encoder.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 id: 'codecs-encoder'
-title: 'Extension method for Encoder'
+title: 'Encoder'
 ---
 
 ## Encoder[A].withFields


### PR DESCRIPTION
Update: docs - with new extension methods to `Encoder`, `Decoder` and `Codec` in circe