### PR TITLE
extras v0.34.0

### DIFF
--- a/changelogs/0.34.0.md
+++ b/changelogs/0.34.0.md
@@ -1,0 +1,4 @@
+## [0.34.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone35) - 2023-03-08
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta8` (#341)


### PR DESCRIPTION
# extras v0.34.0
## [0.34.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone35) - 2023-03-08

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta8` (#341)
