### PR TITLE
extras v0.35.0

### DIFF
--- a/changelogs/0.35.0.md
+++ b/changelogs/0.35.0.md
@@ -1,0 +1,13 @@
+## [0.35.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone36) - 2023-03-08
+
+## New Feature
+* [`extras-render`] Add `contramap` to `Render` (#344)
+  ```scala
+  import java.util.UUID
+  import extras.render.Render
+  
+  final case class Id(value: UUID) extends AnyVal
+  object Id {
+    implicit val idRender: Render[Id] = Render[UUID].contramap(_.value)
+  }
+  ```


### PR DESCRIPTION
# extras v0.35.0
## [0.35.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone36) - 2023-03-08

## New Feature
* [`extras-render`] Add `contramap` to `Render` (#344)
  ```scala
  import java.util.UUID
  import extras.render.Render
  
  final case class Id(value: UUID) extends AnyVal
  object Id {
    implicit val idRender: Render[Id] = Render[UUID].contramap(_.value)
  }
  ```
