### PR TITLE
Close #348 - [`extras-cats`] Add `innerMap` extension method to `F[Option[A]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -2,7 +2,7 @@ package extras.cats.syntax
 
 import cats.data.OptionT
 import cats.{Applicative, Functor}
-import extras.cats.syntax.OptionSyntax.{OptionTAOps, OptionTFAOps, OptionTFOptionOps, OptionTOptionOps}
+import extras.cats.syntax.OptionSyntax._
 
 /** @author Kevin Lee
   * @since 2021-07-22
@@ -18,6 +18,9 @@ trait OptionSyntax {
   implicit def optionTFAOps[F[_], A](fa: F[A]): OptionTFAOps[F, A] = new OptionTFAOps(fa)
 
   implicit def optionTAOps[A](a: A): OptionTAOps[A] = new OptionTAOps(a)
+
+  implicit def fOfOptionInnerOps[F[_], A](fOfOption: F[Option[A]]): FOfOptionInnerOps[F, A] =
+    new FOfOptionInnerOps(fOfOption)
 
 }
 
@@ -39,6 +42,11 @@ object OptionSyntax {
 
   final class OptionTAOps[A](private val a: A) extends AnyVal {
     @inline def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
+  }
+
+  final class FOfOptionInnerOps[F[_], A](private val fOfOption: F[Option[A]]) extends AnyVal {
+    @inline def innerMap[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.map(f))
   }
 
 }

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -26,4 +26,9 @@ trait OptionSyntax {
     inline def someTF[F[_]: Applicative]: OptionT[F, A] = OptionT.some[F](a)
   }
 
+  extension [F[_], A](fOfOption: F[Option[A]]) {
+    inline def innerMap[B](f: A => B)(using F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.map(f))
+  }
+
 }

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -37,6 +37,10 @@ object OptionSyntaxSpec extends Properties {
       "OptionTSupportAllSpec.testAll",
       OptionTSupportAllSpec.testAll,
     ),
+    property(
+      "test F[Option[A]].InnerMap(A => B): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerMap,
+    ),
   )
 
   object OptionTFOptionOpsSpec {
@@ -264,6 +268,29 @@ object OptionSyntaxSpec extends Properties {
       )
 
     }
+
+  }
+
+  object FOfOptionInnerOpsSpec {
+
+    import cats.effect._
+    import extras.cats.syntax.option.fOfOptionInnerOps
+
+    def fab[F[_]: Sync, A](oa: Option[A]): F[Option[A]] = Sync[F].delay(oa)
+
+    def testInnerMap: Property =
+      for {
+        optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
+      } yield {
+        val f: Int => Int = _ * 2
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.map(f)
+
+        input
+          .innerMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
 
   }
 


### PR DESCRIPTION
Close #348 - [`extras-cats`] Add `innerMap` extension method to `F[Option[A]]`