### PR TITLE
Close #349 - [`extras-cats`] Add `innerFlatMap` extension method to `F[Option[A]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -47,6 +47,10 @@ object OptionSyntax {
   final class FOfOptionInnerOps[F[_], A](private val fOfOption: F[Option[A]]) extends AnyVal {
     @inline def innerMap[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.map(f))
+
+    @inline def innerFlatMap[B](f: A => Option[B])(implicit F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.flatMap(f))
+
   }
 
 }

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -29,6 +29,10 @@ trait OptionSyntax {
   extension [F[_], A](fOfOption: F[Option[A]]) {
     inline def innerMap[B](f: A => B)(using F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.map(f))
+
+    inline def innerFlatMap[B](f: A => Option[B])(using F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.flatMap(f))
+
   }
 
 }

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -38,8 +38,12 @@ object OptionSyntaxSpec extends Properties {
       OptionTSupportAllSpec.testAll,
     ),
     property(
-      "test F[Option[A]].InnerMap(A => B): F[Option[B]]",
+      "test F[Option[A]].innerMap(A => B): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerMap,
+    ),
+    property(
+      "test F[Option[A]].innerFlatMap(A => Option[B]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerFlatMap,
     ),
   )
 
@@ -274,6 +278,7 @@ object OptionSyntaxSpec extends Properties {
   object FOfOptionInnerOpsSpec {
 
     import cats.effect._
+    import cats.syntax.option._
     import extras.cats.syntax.option.fOfOptionInnerOps
 
     def fab[F[_]: Sync, A](oa: Option[A]): F[Option[A]] = Sync[F].delay(oa)
@@ -289,6 +294,20 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFlatMap: Property =
+      for {
+        optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
+      } yield {
+        val f: Int => Option[Int] = n => (n * 2).some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.flatMap(f)
+
+        input
+          .innerFlatMap(f)
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -40,8 +40,12 @@ object OptionSyntaxSpec extends Properties {
       OptionTSupportAllSpec.testAll,
     ),
     property(
-      "test F[Option[A]].InnerMap(A => B): F[Option[B]]",
+      "test F[Option[A]].innerMap(A => B): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerMap,
+    ),
+    property(
+      "test F[Option[A]].innerFlatMap(A => Option[B]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerFlatMap,
     ),
   )
 
@@ -281,6 +285,7 @@ object OptionSyntaxSpec extends Properties {
     given rt: IORuntime = IoAppUtils.runtime(ecp.es)
 
     import cats.effect.*
+    import cats.syntax.option.*
     import extras.cats.syntax.option.*
 
     def fab[F[_]: Sync, A](oa: Option[A]): F[Option[A]] = Sync[F].delay(oa)
@@ -296,6 +301,20 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFlatMap: Property =
+      for {
+        optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
+      } yield {
+        val f: Int => Option[Int] = n => (n * 2).some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.flatMap(f)
+
+        input
+          .innerFlatMap(f)
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #349 - [`extras-cats`] Add `innerFlatMap` extension method to `F[Option[A]]`