### PR TITLE
Close #352 - [`extras-cats`] Add `innerFlatMapF` extension method to `F[Option[A]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -1,7 +1,8 @@
 package extras.cats.syntax
 
 import cats.data.OptionT
-import cats.{Applicative, Functor}
+import cats.syntax.option._
+import cats.{Applicative, Functor, Monad}
 import extras.cats.syntax.OptionSyntax._
 
 /** @author Kevin Lee
@@ -50,6 +51,9 @@ object OptionSyntax {
 
     @inline def innerFlatMap[B](f: A => Option[B])(implicit F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.flatMap(f))
+
+    @inline def innerFlatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): F[Option[B]] =
+      F.flatMap(fOfOption)(oa => oa.fold(F.pure(none[B]))(f))
 
   }
 

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -1,6 +1,7 @@
 package extras.cats.syntax
 
-import cats.{Applicative, Functor}
+import cats.{Applicative, Functor, Monad}
+import cats.syntax.option.*
 import cats.data.OptionT
 
 /** @author Kevin Lee
@@ -32,6 +33,9 @@ trait OptionSyntax {
 
     inline def innerFlatMap[B](f: A => Option[B])(using F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.flatMap(f))
+
+    inline def innerFlatMapF[B](f: A => F[Option[B]])(using F: Monad[F]): F[Option[B]] =
+      F.flatMap(fOfOption)(oa => oa.fold(F.pure(none[B]))(f))
 
   }
 

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -45,6 +45,10 @@ object OptionSyntaxSpec extends Properties {
       "test F[Option[A]].innerFlatMap(A => Option[B]): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerFlatMap,
     ),
+    property(
+      "test F[Option[A]].innerFlatMapF(A => F[Option[B]]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerFlatMapF,
+    ),
   )
 
   object OptionTFOptionOpsSpec {
@@ -308,6 +312,20 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerFlatMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFlatMapF: Property =
+      for {
+        optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
+      } yield {
+        val f: Int => Option[Int] = n => (n * 2).some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.flatMap(f)
+
+        input
+          .innerFlatMapF(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -47,6 +47,10 @@ object OptionSyntaxSpec extends Properties {
       "test F[Option[A]].innerFlatMap(A => Option[B]): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerFlatMap,
     ),
+    property(
+      "test F[Option[A]].innerFlatMapF(A => F[Option[B]]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerFlatMapF,
+    ),
   )
 
   object OptionTFOptionOpsSpec {
@@ -315,6 +319,20 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerFlatMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFlatMapF: Property =
+      for {
+        optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
+      } yield {
+        val f: Int => Option[Int] = n => (n * 2).some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.flatMap(f)
+
+        input
+          .innerFlatMapF(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #352 - [`extras-cats`] Add `innerFlatMapF` extension method to `F[Option[A]]`