### PR TITLE
Close #354 - [`extras-cats `] `innerGetOrElse`, `innerGetOrElseF`, `innerFold` and `innerFoldF` to extension methods to `F[Option[A]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -2,7 +2,7 @@ package extras.cats.syntax
 
 import cats.data.OptionT
 import cats.syntax.option._
-import cats.{Applicative, Functor, Monad}
+import cats.{Applicative, FlatMap, Functor, Monad}
 import extras.cats.syntax.OptionSyntax._
 
 /** @author Kevin Lee
@@ -54,6 +54,18 @@ object OptionSyntax {
 
     @inline def innerFlatMapF[B](f: A => F[Option[B]])(implicit F: Monad[F]): F[Option[B]] =
       F.flatMap(fOfOption)(oa => oa.fold(F.pure(none[B]))(f))
+
+    @inline def innerGetOrElse[B >: A](ifEmpty: => B)(implicit F: Functor[F]): F[B] =
+      F.map(fOfOption)(_.getOrElse(ifEmpty))
+
+    @inline def innerGetOrElseF[B >: A](ifEmpty: => F[B])(implicit F: Monad[F]): F[B] =
+      F.flatMap(fOfOption)(_.fold(ifEmpty)(F.pure))
+
+    @inline def innerFold[B](ifEmpty: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
+      F.map(fOfOption)(_.fold(ifEmpty)(f))
+
+    @inline def innerFoldF[B](ifEmpty: => F[B])(f: A => F[B])(implicit F: FlatMap[F]): F[B] =
+      F.flatMap(fOfOption)(_.fold(ifEmpty)(f))
 
   }
 

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -1,6 +1,6 @@
 package extras.cats.syntax
 
-import cats.{Applicative, Functor, Monad}
+import cats.{Applicative, FlatMap, Functor, Monad}
 import cats.syntax.option.*
 import cats.data.OptionT
 
@@ -36,6 +36,18 @@ trait OptionSyntax {
 
     inline def innerFlatMapF[B](f: A => F[Option[B]])(using F: Monad[F]): F[Option[B]] =
       F.flatMap(fOfOption)(oa => oa.fold(F.pure(none[B]))(f))
+
+    inline def innerGetOrElse[B >: A](ifEmpty: => B)(implicit F: Functor[F]): F[B] =
+      F.map(fOfOption)(_.getOrElse(ifEmpty))
+
+    inline def innerGetOrElseF[B >: A](ifEmpty: => F[B])(implicit F: Monad[F]): F[B] =
+      F.flatMap(fOfOption)(_.fold(ifEmpty)(F.pure))
+
+    inline def innerFold[B](ifEmpty: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
+      F.map(fOfOption)(_.fold(ifEmpty)(f))
+
+    inline def innerFoldF[B](ifEmpty: => F[B])(f: A => F[B])(implicit F: FlatMap[F]): F[B] =
+      F.flatMap(fOfOption)(_.fold(ifEmpty)(f))
 
   }
 

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -1,5 +1,6 @@
 package extras.cats.syntax
 
+import cats.syntax.all.*
 import cats.effect.Sync
 import cats.effect.unsafe.IORuntime
 import extras.cats.testing.{ExecutionContextProvider, IoAppUtils}
@@ -50,6 +51,22 @@ object OptionSyntaxSpec extends Properties {
     property(
       "test F[Option[A]].innerFlatMapF(A => F[Option[B]]): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerFlatMapF,
+    ),
+    property(
+      "test F[Option[A]].innerGetOrElse[B >: A](=> B): F[B]",
+      FOfOptionInnerOpsSpec.testInnerGetOrElse,
+    ),
+    property(
+      "test F[Option[A]].innerGetOrElseF[B >: A](=> F[B]): F[B]",
+      FOfOptionInnerOpsSpec.testInnerGetOrElseF,
+    ),
+    property(
+      "test F[Option[A]].innerFold[B >: A](=> B)(A => B): F[B]",
+      FOfOptionInnerOpsSpec.testInnerFold,
+    ),
+    property(
+      "test F[Option[A]].innerFoldF[B >: A](=> F[B])(A => F[B]): F[B]",
+      FOfOptionInnerOpsSpec.testInnerFoldF,
     ),
   )
 
@@ -333,6 +350,77 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerFlatMapF(a => IO.pure(f(a)))
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerGetOrElse: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.getOrElse(defaultValue)
+
+        input
+          .innerGetOrElse(defaultValue)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerGetOrElseF: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.getOrElse(defaultValue)
+
+        input
+          .innerGetOrElseF(IO.pure(defaultValue))
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFold: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val f: Int => Int = _ * 2
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.fold(defaultValue)(f)
+
+        input
+          .innerFold(defaultValue)(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFoldF: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val f: Int => Int = _ * 2
+        val input         = fab[IO, Int](optionN)
+        val expected      = optionN.fold(defaultValue)(f)
+
+        input
+          .innerFoldF(IO.pure(defaultValue))(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #354 - [`extras-cats `] `innerGetOrElse`, `innerGetOrElseF`, `innerFold` and `innerFoldF` to extension methods to `F[Option[A]]`