### PR TITLE
Close #358 - [`extras-cats`] Add `innerLeftMap`, `innerLeftFlatMap` and `innerLeftFlatMapF` extension methods to `F[Either[A, B]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
@@ -59,6 +59,18 @@ object EitherSyntax {
         case Right(b) => f(b)
       }
 
+    @inline def innerLeftMap[C](f: A => C)(implicit F: Functor[F]): F[Either[C, B]] =
+      F.map(fOfEither)(_.leftMap(f))
+
+    @inline def innerLeftFlatMap[C](f: A => Either[C, B])(implicit F: Functor[F]): F[Either[C, B]] =
+      F.map(fOfEither)(_.leftFlatMap(f))
+
+    @inline def innerLeftFlatMapF[C](f: A => F[Either[C, B]])(implicit F: Monad[F]): F[Either[C, B]] =
+      F.flatMap(fOfEither) {
+        case Left(a) => f(a)
+        case Right(b) => F.pure(b.asRight[C])
+      }
+
     @inline def innerGetOrElse[D >: B](ifLeft: => D)(implicit F: Functor[F]): F[D] =
       F.map(fOfEither)(_.getOrElse(ifLeft))
 

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
@@ -42,6 +42,18 @@ trait EitherSyntax {
         case Right(b) => f(b)
       }
 
+    inline def innerLeftMap[C](f: A => C)(using F: Functor[F]): F[Either[C, B]] =
+      F.map(fOfEither)(_.leftMap(f))
+
+    inline def innerLeftFlatMap[C](f: A => Either[C, B])(using F: Functor[F]): F[Either[C, B]] =
+      F.map(fOfEither)(_.leftFlatMap(f))
+
+    inline def innerLeftFlatMapF[C](f: A => F[Either[C, B]])(using F: Monad[F]): F[Either[C, B]] =
+      F.flatMap(fOfEither) {
+        case Left(a) => f(a)
+        case Right(b) => F.pure(b.asRight[C])
+      }
+
     inline def innerGetOrElse[D >: B](ifLeft: => D)(using F: Functor[F]): F[D] =
       F.map(fOfEither)(_.getOrElse(ifLeft))
 

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
@@ -51,12 +51,24 @@ object EitherSyntaxSpec extends Properties {
       FOfEitherInnerOpsSpec.testInnerMap,
     ),
     property(
-      "test F[Either[A, B]].innerFlatMap(A => Either[A, D]): F[Either[A, D]]",
+      "test F[Either[A, B]].innerFlatMap(B => Either[A, D]): F[Either[A, D]]",
       FOfEitherInnerOpsSpec.testInnerFlatMap,
     ),
     property(
-      "test F[Either[A, B]].innerFlatMapF(A => F[Either[A, D]]): F[Either[A, D]]",
+      "test F[Either[A, B]].innerFlatMapF(B => F[Either[A, D]]): F[Either[A, D]]",
       FOfEitherInnerOpsSpec.testInnerFlatMapF,
+    ),
+    property(
+      "test F[Either[A, B]].innerLeftMap(A => C): F[Either[C, B]]",
+      FOfEitherInnerOpsSpec.testInnerLeftMap,
+    ),
+    property(
+      "test F[Either[A, B]].innerLeftFlatMap(A => Either[C, B]): F[Either[C, B]]",
+      FOfEitherInnerOpsSpec.testInnerLeftFlatMap,
+    ),
+    property(
+      "test F[Either[A, B]].innerLeftFlatMapF(A => F[Either[C, B]]): F[Either[C, B]]",
+      FOfEitherInnerOpsSpec.testInnerLeftFlatMapF,
     ),
     property(
       "test F[Either[A, B]].innerGetOrElse[D >: B](=> B): F[D]",
@@ -412,6 +424,66 @@ object EitherSyntaxSpec extends Properties {
 
         input
           .innerFlatMapF(a => IO.pure(f(a)))
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerLeftMap: Property =
+      for {
+        eitherSI <- Gen
+                      .choice1(
+                        Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
+                        Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
+                      )
+                      .log("eitherSI")
+        prefix   <- Gen.string(Gen.alphaNum, Range.linear(5, 10)).log("prefix")
+      } yield {
+        val f: String => String = prefix + _
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.leftMap(f)
+
+        input
+          .innerLeftMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerLeftFlatMap: Property =
+      for {
+        eitherSI <- Gen
+                      .choice1(
+                        Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
+                        Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
+                      )
+                      .log("eitherSI")
+        prefix   <- Gen.string(Gen.alphaNum, Range.linear(5, 10)).log("prefix")
+      } yield {
+        val f: String => Either[String, Int] = a => (prefix + a).asLeft[Int]
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.leftFlatMap(f)
+
+        input
+          .innerLeftFlatMap(f)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerLeftFlatMapF: Property =
+      for {
+        eitherSI <- Gen
+                      .choice1(
+                        Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
+                        Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
+                      )
+                      .log("eitherSI")
+        prefix   <- Gen.string(Gen.alphaNum, Range.linear(5, 10)).log("prefix")
+      } yield {
+        val f: String => Either[String, Int] = a => (prefix + a).asLeft[Int]
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.leftFlatMap(f)
+
+        input
+          .innerLeftFlatMapF(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #358 - [`extras-cats`] Add `innerLeftMap`, `innerLeftFlatMap` and `innerLeftFlatMapF` extension methods to `F[Either[A, B]]`