### PR TITLE
Close #360 - [`extras-cats`] Add `innerFilter`, `innerExists`, `innerContains`, `innerForall`, `innerCollect`, `innerOrElse` and `innerOrElseF` extension methods to `F[Option[A]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/OptionSyntax.scala
@@ -46,6 +46,22 @@ object OptionSyntax {
   }
 
   final class FOfOptionInnerOps[F[_], A](private val fOfOption: F[Option[A]]) extends AnyVal {
+
+    @inline def innerFilter(f: A => Boolean)(implicit F: Functor[F]): F[Option[A]] =
+      F.map(fOfOption)(_.filter(f))
+
+    @inline def innerExists(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.exists(f))
+
+    @inline def innerContains(a: A)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.contains(a))
+
+    @inline def innerForall(f: A => Boolean)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.forall(f))
+
+    @inline def innerCollect[B](pf: PartialFunction[A, B])(implicit F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.collect(pf))
+
     @inline def innerMap[B](f: A => B)(implicit F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.map(f))
 
@@ -60,6 +76,15 @@ object OptionSyntax {
 
     @inline def innerGetOrElseF[B >: A](ifEmpty: => F[B])(implicit F: Monad[F]): F[B] =
       F.flatMap(fOfOption)(_.fold(ifEmpty)(F.pure))
+
+    @inline def innerOrElse[B >: A](alternative: => Option[B])(implicit F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.orElse(alternative))
+
+    @inline def innerOrElseF[B >: A](alternative: => F[Option[B]])(implicit F: Monad[F]): F[Option[B]] =
+      F.flatMap(fOfOption) {
+        case someA @ Some(_) => F.pure(someA)
+        case None => alternative
+      }
 
     @inline def innerFold[B](ifEmpty: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
       F.map(fOfOption)(_.fold(ifEmpty)(f))

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/OptionSyntax.scala
@@ -28,6 +28,22 @@ trait OptionSyntax {
   }
 
   extension [F[_], A](fOfOption: F[Option[A]]) {
+
+    inline def innerFilter(f: A => Boolean)(using F: Functor[F]): F[Option[A]] =
+      F.map(fOfOption)(_.filter(f))
+
+    inline def innerExists(f: A => Boolean)(using F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.exists(f))
+
+    inline def innerContains(a: A)(using F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.contains(a))
+
+    inline def innerForall(f: A => Boolean)(using F: Functor[F]): F[Boolean] =
+      F.map(fOfOption)(_.forall(f))
+
+    inline def innerCollect[B](pf: PartialFunction[A, B])(using F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.collect(pf))
+
     inline def innerMap[B](f: A => B)(using F: Functor[F]): F[Option[B]] =
       F.map(fOfOption)(_.map(f))
 
@@ -37,16 +53,25 @@ trait OptionSyntax {
     inline def innerFlatMapF[B](f: A => F[Option[B]])(using F: Monad[F]): F[Option[B]] =
       F.flatMap(fOfOption)(oa => oa.fold(F.pure(none[B]))(f))
 
-    inline def innerGetOrElse[B >: A](ifEmpty: => B)(implicit F: Functor[F]): F[B] =
+    inline def innerGetOrElse[B >: A](ifEmpty: => B)(using F: Functor[F]): F[B] =
       F.map(fOfOption)(_.getOrElse(ifEmpty))
 
-    inline def innerGetOrElseF[B >: A](ifEmpty: => F[B])(implicit F: Monad[F]): F[B] =
+    inline def innerGetOrElseF[B >: A](ifEmpty: => F[B])(using F: Monad[F]): F[B] =
       F.flatMap(fOfOption)(_.fold(ifEmpty)(F.pure))
 
-    inline def innerFold[B](ifEmpty: => B)(f: A => B)(implicit F: Functor[F]): F[B] =
+    inline def innerOrElse[B >: A](alternative: => Option[B])(using F: Functor[F]): F[Option[B]] =
+      F.map(fOfOption)(_.orElse(alternative))
+
+    inline def innerOrElseF[B >: A](alternative: => F[Option[B]])(using F: Monad[F]): F[Option[B]] =
+      F.flatMap(fOfOption) {
+        case someA @ Some(_) => F.pure(someA)
+        case None => alternative
+      }
+
+    inline def innerFold[B](ifEmpty: => B)(f: A => B)(using F: Functor[F]): F[B] =
       F.map(fOfOption)(_.fold(ifEmpty)(f))
 
-    inline def innerFoldF[B](ifEmpty: => F[B])(f: A => F[B])(implicit F: FlatMap[F]): F[B] =
+    inline def innerFoldF[B](ifEmpty: => F[B])(f: A => F[B])(using F: FlatMap[F]): F[B] =
       F.flatMap(fOfOption)(_.fold(ifEmpty)(f))
 
   }

--- a/modules/extras-cats/shared/src/main/scala/extras/cats/syntax/NamedFunction.scala
+++ b/modules/extras-cats/shared/src/main/scala/extras/cats/syntax/NamedFunction.scala
@@ -1,0 +1,16 @@
+package extras.cats.syntax
+
+import scala.reflect.ClassTag
+
+/** @author Kevin Lee
+  * @since 2023-03-11
+  */
+final case class NamedFunction[A: ClassTag, B: ClassTag](name: String)(f: A => B) extends (A => B) {
+  private val paramAName: String = implicitly[ClassTag[A]].runtimeClass.getSimpleName
+  private val paramBName: String = implicitly[ClassTag[B]].runtimeClass.getSimpleName
+
+  def apply(a: A): B = f(a)
+
+  override val toString: String =
+    s"($paramAName => $paramBName): $name"
+}

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/OptionSyntaxSpec.scala
@@ -41,6 +41,26 @@ object OptionSyntaxSpec extends Properties {
       OptionTSupportAllSpec.testAll,
     ),
     property(
+      "test F[Option[A]].innerFilter(A => Boolean): F[Option[A]]",
+      FOfOptionInnerOpsSpec.testInnerFilter,
+    ),
+    property(
+      "test F[Option[A]].innerExists(A => Boolean): F[Boolean]",
+      FOfOptionInnerOpsSpec.testInnerExists,
+    ),
+    property(
+      "test F[Option[A]].innerContains(A): F[Boolean]",
+      FOfOptionInnerOpsSpec.testInnerContains,
+    ),
+    property(
+      "test F[Option[A]].innerForall(A => Boolean): F[Boolean]",
+      FOfOptionInnerOpsSpec.testInnerForall,
+    ),
+    property(
+      "test F[Option[A]].innerCollect(PartialFunction[A, B]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerCollect,
+    ),
+    property(
       "test F[Option[A]].innerMap(A => B): F[Option[B]]",
       FOfOptionInnerOpsSpec.testInnerMap,
     ),
@@ -59,6 +79,14 @@ object OptionSyntaxSpec extends Properties {
     property(
       "test F[Option[A]].innerGetOrElseF[B >: A](=> F[B]): F[B]",
       FOfOptionInnerOpsSpec.testInnerGetOrElseF,
+    ),
+    property(
+      "test F[Option[A]].innerOrElse[B >: A](=> Option[B]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerOrElse,
+    ),
+    property(
+      "test F[Option[A]].innerOrElseF[B >: A](=> F[Option[B]]): F[Option[B]]",
+      FOfOptionInnerOpsSpec.testInnerOrElseF,
     ),
     property(
       "test F[Option[A]].innerFold[B >: A](=> B)(A => B): F[B]",
@@ -311,6 +339,113 @@ object OptionSyntaxSpec extends Properties {
 
     def fab[F[_]: Sync, A](oa: Option[A]): F[Option[A]] = Sync[F].delay(oa)
 
+    def testInnerFilter: Property =
+      for {
+        n       <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        optionN <- Gen.constant(n).option.log("optionN")
+        filterF <- Gen
+                     .element1(
+                       NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                       NamedFunction("Always false")((_: Int) => false),
+                     )
+                     .log("filterF")
+      } yield {
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.filter(filterF)
+
+        input
+          .innerFilter(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerExists: Property =
+      for {
+        n       <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        optionN <- Gen.constant(n).option.log("optionN")
+        filterF <- Gen
+                     .element1(
+                       NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                       NamedFunction("Always false")((_: Int) => false),
+                     )
+                     .log("filterF")
+      } yield {
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.exists(filterF)
+
+        input
+          .innerExists(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerContains: Property =
+      for {
+        n         <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        optionN   <- Gen.constant(n).option.log("optionN")
+        toCompare <- Gen
+                       .element1(
+                         n,
+                         n + 10,
+                       )
+                       .log("toCompare")
+      } yield {
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.contains(toCompare)
+
+        input
+          .innerContains(toCompare)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerForall: Property =
+      for {
+        n       <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        optionN <- Gen.constant(n).option.log("optionN")
+        filterF <- Gen
+                     .element1(
+                       NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                       NamedFunction("Always false")((_: Int) => false),
+                     )
+                     .log("filterF")
+      } yield {
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.forall(filterF)
+
+        input
+          .innerForall(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerCollect: Property =
+      for {
+        n       <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        optionN <- Gen.constant(n).option.log("optionN")
+        filterF <- Gen
+                     .element1(
+                       NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                       NamedFunction("Always false")((_: Int) => false),
+                     )
+                     .log("filterF")
+
+      } yield {
+        val alternative = n + 10
+
+        val input = fab[IO, Int](optionN)
+
+        val pf: PartialFunction[Int, Int] = {
+          case `n` => if (filterF(n)) n else alternative
+        }
+
+        val expected = optionN.collect(pf)
+
+        input
+          .innerCollect(pf)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
     def testInnerMap: Property =
       for {
         optionN <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).option.log("optionN")
@@ -384,6 +519,44 @@ object OptionSyntaxSpec extends Properties {
 
         input
           .innerGetOrElseF(IO.pure(defaultValue))
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerOrElse: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val defaultOption = defaultValue.some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.orElse(defaultOption)
+
+        input
+          .innerOrElse(defaultOption)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerOrElseF: Property =
+      for {
+        defaultValue <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
+        optionN      <- Gen
+                          .int(Range.linear(Int.MinValue, Int.MaxValue))
+                          .map { n => if (n === defaultValue) n + 1 else n }
+                          .option
+                          .log("optionN")
+      } yield {
+        val defaultOption = defaultValue.some
+
+        val input    = fab[IO, Int](optionN)
+        val expected = optionN.orElse(defaultOption)
+
+        input
+          .innerOrElseF(IO.pure(defaultOption))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #360 - [`extras-cats`] Add `innerFilter`, `innerExists`, `innerContains`, `innerForall`, `innerCollect`, `innerOrElse` and `innerOrElseF` extension methods to `F[Option[A]]`