### PR TITLE
Close #362 - [`extras-cats`] Add `innerFind`, `innerFilterOrElse`, `innerExists`, `innerForall`, `innerContains`, `innerCollectFirst`, `innerOrElse` and `innerOrElseF` extension methods to `F[Either[A, B]]`

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
@@ -3,6 +3,7 @@ package extras.cats.syntax
 import EitherSyntax.{EitherTAOps, EitherTEitherOps, EitherTFAOps, EitherTFEitherOps, FOfEitherInnerOps}
 import cats.data.EitherT
 import cats.syntax.either._
+import cats.syntax.foldable._
 import cats.{Applicative, FlatMap, Functor, Monad}
 
 /** @author Kevin Lee
@@ -47,6 +48,25 @@ object EitherSyntax {
   }
 
   final class FOfEitherInnerOps[F[_], A, B](private val fOfEither: F[Either[A, B]]) extends AnyVal {
+
+    @inline def innerFind(f: B => Boolean)(implicit F: Functor[F]): F[Option[B]] =
+      F.map(fOfEither)(_.find(f))
+
+    @inline def innerFilterOrElse[C >: A](f: B => Boolean, leftIfFalse: => C)(implicit F: Functor[F]): F[Either[C, B]] =
+      F.map(fOfEither)(_.filterOrElse(f, leftIfFalse))
+
+    @inline def innerExists(f: B => Boolean)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfEither)(_.exists(f))
+
+    @inline def innerForall(f: B => Boolean)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfEither)(_.forall(f))
+
+    @inline def innerContains(b: B)(implicit F: Functor[F]): F[Boolean] =
+      F.map(fOfEither)(_.contains(b))
+
+    @inline def innerCollectFirst[D >: B](pf: PartialFunction[B, D])(implicit F: Functor[F]): F[Option[D]] =
+      F.map(fOfEither)(_.collectFirst(pf))
+
     @inline def innerMap[D](f: B => D)(implicit F: Functor[F]): F[Either[A, D]] =
       F.map(fOfEither)(_.map(f))
 
@@ -76,6 +96,15 @@ object EitherSyntax {
 
     @inline def innerGetOrElseF[D >: B](ifLeft: => F[D])(implicit F: Monad[F]): F[D] =
       F.flatMap(fOfEither)(_.fold(_ => ifLeft, F.pure))
+
+    @inline def innerOrElse[C >: A, D >: B](ifLeft: => Either[C, D])(implicit F: Functor[F]): F[Either[C, D]] =
+      F.map(fOfEither)(_.orElse(ifLeft))
+
+    @inline def innerOrElseF[C >: A, D >: B](ifLeft: => F[Either[C, D]])(implicit F: Monad[F]): F[Either[C, D]] =
+      F.flatMap(fOfEither) {
+        case r @ Right(_) => F.pure(r)
+        case Left(_) => ifLeft
+      }
 
     @inline def innerFold[D](ifLeft: => D)(f: B => D)(implicit F: Functor[F]): F[D] =
       F.map(fOfEither)(_.fold(_ => ifLeft, f))

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/EitherSyntaxSpec.scala
@@ -1,5 +1,6 @@
 package extras.cats.syntax
 
+import cats.syntax.all._
 import hedgehog._
 import hedgehog.runner._
 
@@ -47,6 +48,30 @@ object EitherSyntaxSpec extends Properties {
       EitherTSupportAllSpec.testAll,
     ),
     property(
+      "test F[Either[A, B]].innerFind(B => Boolean): F[Option[B]",
+      FOfEitherInnerOpsSpec.testInnerFind,
+    ),
+    property(
+      "test F[Either[A, B]].innerFilterOrElse[C >: A](B => Boolean, => C): F[Either[C, B]]",
+      FOfEitherInnerOpsSpec.testInnerFilterOrElse,
+    ),
+    property(
+      "test F[Either[A, B]].innerExists(B => Boolean): F[Boolean]",
+      FOfEitherInnerOpsSpec.testInnerExists,
+    ),
+    property(
+      "test F[Either[A, B]].innerForall(B => Boolean): F[Boolean]",
+      FOfEitherInnerOpsSpec.testInnerForall,
+    ),
+    property(
+      "test F[Either[A, B]].innerContains(B): F[Boolean]",
+      FOfEitherInnerOpsSpec.testInnerContains,
+    ),
+    property(
+      "test F[Either[A, B]].innerCollectFirst[D >: B](PartialFunction[B, D]): F[D]",
+      FOfEitherInnerOpsSpec.testInnerCollectFirst,
+    ),
+    property(
       "test F[Either[A, B]].innerMap(B => D): F[Either[A, D]]",
       FOfEitherInnerOpsSpec.testInnerMap,
     ),
@@ -77,6 +102,14 @@ object EitherSyntaxSpec extends Properties {
     property(
       "test F[Either[A, B]].innerGetOrElseF[D >: B](=> F[B]): F[D]",
       FOfEitherInnerOpsSpec.testInnerGetOrElseF,
+    ),
+    property(
+      "test F[Either[A, B]].innerOrElse[C >: A, D >: B](=> Either[C, D]): F[Either[C, D]]",
+      FOfEitherInnerOpsSpec.testInnerOrElse,
+    ),
+    property(
+      "test F[Either[A, B]].innerOrElseF[C >: A, D >: B](=> F[Either[C, D]]): F[Either[C, D]]",
+      FOfEitherInnerOpsSpec.testInnerOrElseF,
     ),
     property(
       "test F[Either[A, B]].innerFold[D](=> D)(B => D): F[D]",
@@ -370,6 +403,155 @@ object EitherSyntaxSpec extends Properties {
 
     def fab[F[_]: Sync, A, B](eab: Either[A, B]): F[Either[A, B]] = Sync[F].delay(eab)
 
+    def testInnerFind: Property =
+      for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        eitherSI <- Gen
+                      .choice1(
+                        Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
+                        Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
+                      )
+                      .log("eitherSI")
+        filterF  <- Gen
+                      .element1(
+                        NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                        NamedFunction("Always false")((_: Int) => false),
+                      )
+                      .log("filterF")
+
+      } yield {
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.find(filterF)
+
+        input
+          .innerFind(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerFilterOrElse: Property =
+      for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        eitherSI <- Gen
+                      .choice1(
+                        Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
+                        Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
+                      )
+                      .log("eitherSI")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        filterF  <- Gen
+                      .element1(
+                        NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                        NamedFunction("Always false")((_: Int) => false),
+                      )
+                      .log("filterF")
+
+      } yield {
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.filterOrElse(filterF, s)
+
+        input
+          .innerFilterOrElse(filterF, s)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerExists: Property =
+      for {
+        n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+        filterF  <- Gen
+                      .element1(
+                        NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                        NamedFunction("Always false")((_: Int) => false),
+                      )
+                      .log("filterF")
+      } yield {
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.exists(filterF)
+
+        input
+          .innerExists(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerForall: Property =
+      for {
+        n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+        filterF  <- Gen
+                      .element1(
+                        NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                        NamedFunction("Always false")((_: Int) => false),
+                      )
+                      .log("filterF")
+      } yield {
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.forall(filterF)
+
+        input
+          .innerForall(filterF)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerContains: Property =
+      for {
+        n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+
+        eitherSI  <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+        toCompare <- Gen
+                       .element1(
+                         n,
+                         n + 10,
+                       )
+                       .log("toCompare")
+      } yield {
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.contains(toCompare)
+
+        input
+          .innerContains(toCompare)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerCollectFirst: Property =
+      for {
+        n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
+        filterF <- Gen
+                     .element1(
+                       NamedFunction(s"The number should be equal to ${n.toString}")((a: Int) => a === n),
+                       NamedFunction("Always false")((_: Int) => false),
+                     )
+                     .log("filterF")
+
+      } yield {
+        val alternative = n + 10
+
+        val input = fab[IO, String, Int](eitherSI)
+
+        val pf: PartialFunction[Int, Int] = {
+          case `n` => if (filterF(n)) n else alternative
+        }
+
+        val expected = eitherSI.collectFirst(pf)
+
+        input
+          .innerCollectFirst(pf)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
     def testInnerMap: Property =
       for {
         eitherSI <- Gen
@@ -520,6 +702,42 @@ object EitherSyntaxSpec extends Properties {
 
         input
           .innerGetOrElseF(IO.pure(defaultLeft))
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerOrElse: Property =
+      for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
+        prefix        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("prefix")
+        defaultEither <- Gen.element1((n + 10).asRight[String], (prefix + s).asLeft[Int]).log("defaultEither")
+
+      } yield {
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.orElse(defaultEither)
+
+        input
+          .innerOrElse(defaultEither)
+          .map(actual => actual ==== expected)
+      }.unsafeRunSync()
+
+    def testInnerOrElseF: Property =
+      for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
+        prefix        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("prefix")
+        defaultEither <- Gen.element1((n + 10).asRight[String], (prefix + s).asLeft[Int]).log("defaultEither")
+
+      } yield {
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.orElse(defaultEither)
+
+        input
+          .innerOrElseF(IO.pure(defaultEither))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #362 - [`extras-cats`] Add `innerFind`, `innerFilterOrElse`, `innerExists`, `innerForall`, `innerContains`, `innerCollectFirst`, `innerOrElse` and `innerOrElseF` extension methods to `F[Either[A, B]]`