### PR TITLE
Close #368 - [`extras-cats`] Fix `innerFold` and `innerFoldF` for `F[Either[A, B]]` to have the same method signature as `Either`'s

### DIFF
--- a/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-2/extras/cats/syntax/EitherSyntax.scala
@@ -106,11 +106,11 @@ object EitherSyntax {
         case Left(_) => ifLeft
       }
 
-    @inline def innerFold[D](ifLeft: => D)(f: B => D)(implicit F: Functor[F]): F[D] =
-      F.map(fOfEither)(_.fold(_ => ifLeft, f))
+    @inline def innerFold[D](forLeft: A => D)(forRight: B => D)(implicit F: Functor[F]): F[D] =
+      F.map(fOfEither)(_.fold(forLeft, forRight))
 
-    @inline def innerFoldF[D](ifLeft: => F[D])(f: B => F[D])(implicit F: FlatMap[F]): F[D] =
-      F.flatMap(fOfEither)(_.fold(_ => ifLeft, f))
+    @inline def innerFoldF[D](forLeft: A => F[D])(forRight: B => F[D])(implicit F: FlatMap[F]): F[D] =
+      F.flatMap(fOfEither)(_.fold(forLeft, forRight))
 
   }
 

--- a/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
+++ b/modules/extras-cats/shared/src/main/scala-3/extras/cats/syntax/EitherSyntax.scala
@@ -89,11 +89,11 @@ trait EitherSyntax {
         case Left(_) => ifLeft
       }
 
-    inline def innerFold[D](ifLeft: => D)(f: B => D)(using F: Functor[F]): F[D] =
-      F.map(fOfEither)(_.fold(_ => ifLeft, f))
+    inline def innerFold[D](forLeft: A => D)(forRight: B => D)(using F: Functor[F]): F[D] =
+      F.map(fOfEither)(_.fold(forLeft, forRight))
 
-    inline def innerFoldF[D](ifLeft: => F[D])(f: B => F[D])(using F: FlatMap[F]): F[D] =
-      F.flatMap(fOfEither)(_.fold(_ => ifLeft, f))
+    inline def innerFoldF[D](forLeft: A => F[D])(forRight: B => F[D])(using F: FlatMap[F]): F[D] =
+      F.flatMap(fOfEither)(_.fold(forLeft, forRight))
   }
 
 }

--- a/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/AllSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-2/extras/cats/syntax/AllSyntaxSpec.scala
@@ -1324,40 +1324,39 @@ object AllSyntaxSpec extends Properties {
 
     def testInnerFold: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
 
         val input    = fab[IO, String, Int](eitherSI)
         val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFold(defaultLeft)(f)
+          .innerFold(lf)(f)
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 
     def testInnerFoldF: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
-        val input         = fab[IO, String, Int](eitherSI)
-        val expected      = eitherSI.fold(_ => defaultLeft, f)
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFoldF(IO.pure(defaultLeft))(a => IO.pure(f(a)))
+          .innerFoldF(l => IO.pure(lf(l)))(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/AllSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/AllSyntaxSpec.scala
@@ -1277,40 +1277,39 @@ object AllSyntaxSpec extends Properties {
 
     def testInnerFold: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
 
         val input    = fab[IO, String, Int](eitherSI)
         val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFold(defaultLeft)(f)
+          .innerFold(lf)(f)
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 
     def testInnerFoldF: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
-        val input         = fab[IO, String, Int](eitherSI)
-        val expected      = eitherSI.fold(_ => defaultLeft, f)
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFoldF(IO.pure(defaultLeft))(a => IO.pure(f(a)))
+          .innerFoldF(l => IO.pure(lf(l)))(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 

--- a/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/EitherSyntaxSpec.scala
+++ b/modules/extras-cats/shared/src/test/scala-3/extras/cats/syntax/EitherSyntaxSpec.scala
@@ -745,40 +745,39 @@ class EitherSyntaxSpec extends Properties {
 
     def testInnerFold: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
 
         val input    = fab[IO, String, Int](eitherSI)
         val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFold(defaultLeft)(f)
+          .innerFold(lf)(f)
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 
     def testInnerFoldF: Property =
       for {
+        n        <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+        s        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s")
+        eitherSI <- Gen.element1(n.asRight[String], s.asLeft[Int]).log("eitherSI")
+
         defaultLeft <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("defaultValue")
-        eitherSI    <- Gen
-                         .choice1(
-                           Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).map(_.asRight[String]),
-                           Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(_.asLeft[Int]),
-                         )
-                         .log("eitherSI")
       } yield {
-        val f: Int => Int = _ * 2
-        val input         = fab[IO, String, Int](eitherSI)
-        val expected      = eitherSI.fold(_ => defaultLeft, f)
+        val f: Int => Int     = _ * 2
+        val lf: String => Int = leftValue => if (leftValue === s) defaultLeft else defaultLeft + 10
+
+        val input    = fab[IO, String, Int](eitherSI)
+        val expected = eitherSI.fold(_ => defaultLeft, f)
 
         input
-          .innerFoldF(IO.pure(defaultLeft))(a => IO.pure(f(a)))
+          .innerFoldF(l => IO.pure(lf(l)))(a => IO.pure(f(a)))
           .map(actual => actual ==== expected)
       }.unsafeRunSync()
 


### PR DESCRIPTION
Close #368 - [`extras-cats`] Fix `innerFold` and `innerFoldF` for `F[Either[A, B]]` to have the same method signature as `Either`'s