### PR TITLE
extras v0.37.0

### DIFF
--- a/changelogs/0.37.0.md
+++ b/changelogs/0.37.0.md
@@ -1,0 +1,21 @@
+## [0.37.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone38) - 2023-03-13
+
+## Changes
+* [`extras-cats`] Fix `innerFold` and `innerFoldF` for `F[Either[A, B]]` to have the same method signature as `Either`'s (#368)
+  * `innerFold`
+    ```scala
+    def innerFold[D](ifLeft: => D)(f: B => D)(implicit F: Functor[F]): F[D]
+    ```
+    to
+    ```scala
+    def innerFold[D](forLeft: A => D)(forRight: B => D)(implicit F: Functor[F]): F[D]
+    ```
+  
+  * `innerFoldF`
+    ```scala
+    def innerFoldF[D](ifLeft: => F[D])(f: B => F[D])(implicit F: FlatMap[F]): F[D]
+    ```
+    to
+    ```scala
+    def innerFoldF[D](forLeft: A => F[D])(forRight: B => F[D])(implicit F: FlatMap[F]): F[D]
+    ```


### PR DESCRIPTION
# extras v0.37.0
## [0.37.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone38) - 2023-03-13

## Changes
* [`extras-cats`] Fix `innerFold` and `innerFoldF` for `F[Either[A, B]]` to have the same method signature as `Either`'s (#368)
  * `innerFold`
    ```scala
    def innerFold[D](ifLeft: => D)(f: B => D)(implicit F: Functor[F]): F[D]
    ```
    to
    ```scala
    def innerFold[D](forLeft: A => D)(forRight: B => D)(implicit F: Functor[F]): F[D]
    ```
  
  * `innerFoldF`
    ```scala
    def innerFoldF[D](ifLeft: => F[D])(f: B => F[D])(implicit F: FlatMap[F]): F[D]
    ```
    to
    ```scala
    def innerFoldF[D](forLeft: A => F[D])(forRight: B => F[D])(implicit F: FlatMap[F]): F[D]
    ```
