### PR TITLE
extras v0.38.0

### DIFF
--- a/changelogs/0.38.0.md
+++ b/changelogs/0.38.0.md
@@ -1,0 +1,8 @@
+## [0.38.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone39) - 2023-03-19
+
+## New Feature
+* Add `newtype` support for `doobie` (#378)
+
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0-beta9` (#376)


### PR DESCRIPTION
# extras v0.38.0
## [0.38.0](https://github.com/Kevin-Lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone39) - 2023-03-19

## New Feature
* Add `newtype` support for `doobie` (#378)


## Internal Housekeeping
* Upgrade `effectie` to `2.0.0-beta9` (#376)
