### PR TITLE
extras v0.40.0

### DIFF
--- a/changelogs/0.40.0.md
+++ b/changelogs/0.40.0.md
@@ -1,0 +1,5 @@
+## [0.40.0](https://github.com/kevin-lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone41) - 2023-08-19
+
+## Internal Housekeeping
+* Upgrade `sbt` to `1.9.3` (#399)
+* Upgrade `effectie` to `2.0.0-beta11` (#402)


### PR DESCRIPTION
# extras v0.40.0
## [0.40.0](https://github.com/kevin-lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone41) - 2023-08-19

## Internal Housekeeping
* Upgrade `sbt` to `1.9.3` (#399)
* Upgrade `effectie` to `2.0.0-beta11` (#402)
