### PR TITLE
Close #409 - Add `syntax` for `Long` and add `toOrdinal`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/numeric.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/numeric.scala
@@ -5,6 +5,8 @@ package extras.strings.syntax
   */
 trait numeric {
   implicit def ints(n: Int): numeric.Ints = new numeric.Ints(n)
+
+  implicit def longs(n: Long): numeric.Longs = new numeric.Longs(n)
 }
 object numeric extends numeric {
   final class Ints(private val n: Int) extends AnyVal {
@@ -22,4 +24,21 @@ object numeric extends numeric {
             }
         })
   }
+
+  final class Longs(private val n: Long) extends AnyVal {
+    @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+    def toOrdinal: String =
+      n.toString +
+        (n % 100L match {
+          case 11L | 12L | 13L => "th"
+          case _ =>
+            n % 10L match {
+              case 1L => "st"
+              case 2L => "nd"
+              case 3L => "rd"
+              case _ => "th"
+            }
+        })
+  }
+
 }

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/numericSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/numericSpec.scala
@@ -7,7 +7,7 @@ import hedgehog.runner._
   * @since 2023-08-21
   */
 object numericSpec extends Properties {
-  override def tests: List[Test] = intsSpec.tests
+  override def tests: List[Test] = intsSpec.tests ++ longsSpec.tests
 
   object intsSpec {
     def tests: List[Test] = List(
@@ -18,6 +18,26 @@ object numericSpec extends Properties {
       for {
         (n, expected) <- Gen
                            .int(Range.linear(0, Int.MaxValue))
+                           .map(num => num -> ordinal(num.toLong))
+                           .log("(n, expected)")
+      } yield {
+        import extras.strings.syntax.numeric._
+
+        val actual = n.toOrdinal
+        actual ==== expected
+      }
+
+  }
+
+  object longsSpec {
+    def tests: List[Test] = List(
+      property("test Long.toOrdinal", testToOrdinal)
+    )
+
+    def testToOrdinal: Property =
+      for {
+        (n, expected) <- Gen
+                           .long(Range.linear(0L, Long.MaxValue))
                            .map(num => num -> ordinal(num))
                            .log("(n, expected)")
       } yield {
@@ -29,10 +49,11 @@ object numericSpec extends Properties {
 
   }
 
-  def ordinal(n: Int): String = {
+  def ordinal(n: Long): String = {
     val suffixes = Array("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
-    val i        = n % 100
-    val j        = if (i > 10 && i < 20) 0 else (n % 10)
-    n.toString + suffixes(j)
+
+    val i = n % 100L
+    val j = if (i > 10L && i < 20L) 0 else (n % 10L)
+    n.toString + suffixes(j.toInt)
   }
 }


### PR DESCRIPTION
Close #409 - Add `syntax` for `Long` and add `toOrdinal`