### PR TITLE
Close #412 - [`extras-string`] Add `commaAnd` syntax for `Seq[String]`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
@@ -1,0 +1,19 @@
+package extras.strings.syntax
+
+/** @author Kevin Lee
+  * @since 2023-08-22
+  */
+trait strings {
+  implicit def stringListOps(ss: Seq[String]): strings.StringListOps = new strings.StringListOps(ss)
+}
+object strings extends strings {
+  @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
+  final class StringListOps(private val ss: Seq[String]) extends AnyVal {
+    def commaAnd: String = ss match {
+      case Seq() => ""
+      case Seq(s) => s
+      case Seq(s1, s2) => s"$s1 and $s2"
+      case _ => s"${ss.dropRight(1).mkString(", ")} and ${ss.last}"
+    }
+  }
+}

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -1,0 +1,51 @@
+package extras.strings.syntax
+
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2023-08-22
+  */
+object stringsSpec extends Properties {
+  override def tests: List[Test] = List(
+    example("test List[String].empty.commaAnd", testEmptyListCommaAnd),
+    example("test List(\"\").commaAnd", testListWithSingleEmptyStringCommaAnd),
+    property("test List[String].commaAnd", testCommaAnd),
+  )
+
+  def testEmptyListCommaAnd: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List.empty[String].commaAnd
+    actual ==== expected
+  }
+
+  def testListWithSingleEmptyStringCommaAnd: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List("").commaAnd
+    actual ==== expected
+  }
+
+  def testCommaAnd: Property =
+    for {
+      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+      (list, expected) <- Gen
+                            .constant(ss match {
+                              case Nil =>
+                                (List(last), last)
+                              case _ =>
+                                (ss ++ List(last), s"${ss.mkString(", ")} and $last")
+                            })
+                            .log("(list, expected)")
+    } yield {
+      import extras.strings.syntax.strings._
+
+      val actual = list.commaAnd
+      actual ==== expected
+    }
+}


### PR DESCRIPTION
Close #412 - [`extras-string`] Add `commaAnd` syntax for `Seq[String]`