### PR TITLE
Close #414 - [`extras-string`] Add `serialCommaAnd` syntax for `Seq[String]`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
@@ -39,5 +39,37 @@ object strings extends strings {
       case Seq(s1, s2) => s"$s1 and $s2"
       case _ => s"${ss.dropRight(1).mkString(", ")} and ${ss.last}"
     }
+
+    /** join a Seq[String] with , (comma) and the last and the second last elements should be also connected with and (Oxford comma / Harvard comma).
+      *
+      * @example
+      * {{{
+      *   List.empty
+      *   // String = ""
+      *
+      *   List("")
+      *   // String = ""
+      *
+      *   List("aaa")
+      *   // String = "aaa"
+      *
+      *   List("aaa", "bbb")
+      *   // String = "aaa and bbb"
+      *
+      *   List("aaa", "bbb", "ccc")
+      *   // String = "aaa, bbb, and ccc"
+      *
+      *   List("aaa", "bbb", "ccc", "ddd")
+      *   // String = "aaa, bbb, ccc, and ddd"
+      *
+      * }}}
+      */
+    @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
+    def serialCommaAnd: String = ss match {
+      case Seq() => ""
+      case Seq(s) => s
+      case Seq(s1, s2) => s"$s1 and $s2"
+      case _ => s"${ss.dropRight(1).mkString(", ")}, and ${ss.last}"
+    }
   }
 }

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -11,6 +11,9 @@ object stringsSpec extends Properties {
     example("test List[String].empty.commaAnd", testEmptyListCommaAnd),
     example("test List(\"\").commaAnd", testListWithSingleEmptyStringCommaAnd),
     property("test List[String].commaAnd", testCommaAnd),
+    example("test List[String].empty.serialCommaAnd", testEmptyListSerialCommaAnd),
+    example("test List(\"\").serialCommaAnd", testListWithSingleEmptyStringSerialCommaAnd),
+    property("test List[String].serialCommaAnd", testSerialCommaAnd),
   )
 
   def testEmptyListCommaAnd: Result = {
@@ -48,4 +51,43 @@ object stringsSpec extends Properties {
       val actual = list.commaAnd
       actual ==== expected
     }
+
+  def testEmptyListSerialCommaAnd: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List.empty[String].serialCommaAnd
+    actual ==== expected
+  }
+
+  def testListWithSingleEmptyStringSerialCommaAnd: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List("").serialCommaAnd
+    actual ==== expected
+  }
+
+  def testSerialCommaAnd: Property =
+    for {
+      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+      (list, expected) <- Gen
+                            .constant(ss match {
+                              case Nil =>
+                                (List(last), last)
+                              case s :: Nil =>
+                                (ss ++ List(last), s"$s and $last")
+                              case _ =>
+                                (ss ++ List(last), s"${ss.mkString(", ")}, and $last")
+                            })
+                            .log("(list, expected)")
+    } yield {
+      import extras.strings.syntax.strings._
+
+      val actual = list.serialCommaAnd
+      actual ==== expected
+    }
+
 }


### PR DESCRIPTION
Close #414 - [`extras-string`] Add `serialCommaAnd` syntax for `Seq[String]`