### PR TITLE
Close #419 - [extras-string] Add commaWith syntax for Seq[String]

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
@@ -10,6 +10,37 @@ object strings extends strings {
   @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   final class StringSeqOps(private val ss: Seq[String]) extends AnyVal {
 
+    /** Join Seq[String] with , (comma) expect for the last and the second last one which are connected with the given conjunction.
+      *
+      * @example
+      * {{{
+      *   List.empty[String].commaWith("blah")
+      *   // String = ""
+      *
+      *   List("").commaWith("blah")
+      *   // String = ""
+      *
+      *   List("aaa").commaWith("blah")
+      *   // String = "aaa"
+      *
+      *   List("aaa", "bbb").commaWith("blah")
+      *   // String = "aaa blah bbb"
+      *
+      *   List("aaa", "bbb", "ccc").commaWith("blah")
+      *   // String = "aaa, bbb blah ccc"
+      *
+      *   List("aaa", "bbb", "ccc", "ddd").commaWith("blah")
+      *   // String = "aaa, bbb, ccc blah ddd"
+      *
+      * }}}
+      */
+    def commaWith(conjunction: String): String = ss match {
+      case Seq() => ""
+      case Seq(s) => s
+      case Seq(s1, s2) => s"$s1 $conjunction $s2"
+      case _ => s"${ss.dropRight(1).mkString(", ")} $conjunction ${ss.last}"
+    }
+
     /** join Seq[String] with , (comma) expect for the last and the second last one which are connected with `and`.
       * @example
       * {{{
@@ -33,12 +64,7 @@ object strings extends strings {
       *
       * }}}
       */
-    def commaAnd: String = ss match {
-      case Seq() => ""
-      case Seq(s) => s
-      case Seq(s1, s2) => s"$s1 and $s2"
-      case _ => s"${ss.dropRight(1).mkString(", ")} and ${ss.last}"
-    }
+    def commaAnd: String = commaWith("and")
 
     /** join a Seq[String] with , (comma) and the last and the second last elements should be also connected with and (Oxford comma / Harvard comma).
       *

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -8,13 +8,59 @@ import hedgehog.runner._
   */
 object stringsSpec extends Properties {
   override def tests: List[Test] = List(
-    example("test List[String].empty.commaAnd", testEmptyListCommaAnd),
+    property("test List.empty[String].commaWith", testEmptyListCommaWith),
+    property("test List(\"\").commaWith", testListWithSingleEmptyStringCommaWith),
+    property("test List[String].commaWith", testCommaWith),
+    example("test List.empty[String].commaAnd", testEmptyListCommaAnd),
     example("test List(\"\").commaAnd", testListWithSingleEmptyStringCommaAnd),
     property("test List[String].commaAnd", testCommaAnd),
-    example("test List[String].empty.serialCommaAnd", testEmptyListSerialCommaAnd),
+    example("test List.empty[String].serialCommaAnd", testEmptyListSerialCommaAnd),
     example("test List(\"\").serialCommaAnd", testListWithSingleEmptyStringSerialCommaAnd),
     property("test List[String].serialCommaAnd", testSerialCommaAnd),
   )
+
+  def testEmptyListCommaWith: Property = for {
+    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
+  } yield {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List.empty[String].commaWith(conjunction)
+    actual ==== expected
+  }
+
+  def testListWithSingleEmptyStringCommaWith: Property = for {
+    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
+  } yield {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List("").commaWith(conjunction)
+    actual ==== expected
+  }
+
+  def testCommaWith: Property =
+    for {
+      conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
+      ss          <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      last        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+      (list, expected) <- Gen
+                            .constant(ss match {
+                              case Nil =>
+                                (List(last), last)
+                              case _ =>
+                                (ss ++ List(last), s"${ss.mkString(", ")} $conjunction $last")
+                            })
+                            .log("(list, expected)")
+    } yield {
+      import extras.strings.syntax.strings._
+
+      val actual = list.commaWith(conjunction)
+      actual ==== expected
+    }
+
+  ///
 
   def testEmptyListCommaAnd: Result = {
     import extras.strings.syntax.strings._
@@ -51,6 +97,8 @@ object stringsSpec extends Properties {
       val actual = list.commaAnd
       actual ==== expected
     }
+
+  ///
 
   def testEmptyListSerialCommaAnd: Result = {
     import extras.strings.syntax.strings._


### PR DESCRIPTION
Close #419 - [`extras-string`] Add `commaWith` syntax for `Seq[String]`