### PR TITLE
Close #416 - [`extras-string`] Add `commaOr` syntax for `Seq[String]`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
@@ -124,6 +124,32 @@ object strings extends strings {
       */
     def serialCommaAnd: String = serialCommaWith("and")
 
+    /** Format Seq[String] into a human-readable list using comma and the conjunction `or`.
+      * It separates elements by commas and uses the term `or` before the last element.
+      * @example
+      * {{{
+      *   List.empty[String].commaOr
+      *   // String = ""
+      *
+      *   List("").commaOr
+      *   // String = ""
+      *
+      *   List("aaa").commaOr
+      *   // String = "aaa"
+      *
+      *   List("aaa", "bbb").commaOr
+      *   // String = "aaa or bbb"
+      *
+      *   List("aaa", "bbb", "ccc").commaOr
+      *   // String = "aaa, bbb or ccc"
+      *
+      *   List("aaa", "bbb", "ccc", "ddd").commaOr
+      *   // String = "aaa, bbb, ccc or ddd"
+      *
+      * }}}
+      */
+    def commaOr: String = commaWith("or")
+
   }
 
 }

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -23,6 +23,10 @@ object stringsSpec extends Properties {
     example("test List.empty[String].serialCommaAnd", testEmptyListSerialCommaAnd),
     example("test List(\"\").serialCommaAnd", testListWithSingleEmptyStringSerialCommaAnd),
     property("test List[String].serialCommaAnd", testSerialCommaAnd),
+    //
+    example("test List.empty[String].commaOr", testEmptyListCommaOr),
+    example("test List(\"\").commaOr", testListWithSingleEmptyStringCommaOr),
+    property("test List[String].commaOr", testCommaOr),
   )
 
   def testEmptyListCommaWith: Property = for {
@@ -190,5 +194,45 @@ object stringsSpec extends Properties {
       val actual = list.serialCommaAnd
       actual ==== expected
     }
+
+
+  ///
+
+  def testEmptyListCommaOr: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual = List.empty[String].commaOr
+    actual ==== expected
+  }
+
+  def testListWithSingleEmptyStringCommaOr: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual = List("").commaOr
+    actual ==== expected
+  }
+
+  def testCommaOr: Property =
+    for {
+      ss <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+      (list, expected) <- Gen
+        .constant(ss match {
+          case Nil =>
+            (List(last), last)
+          case _ =>
+            (ss ++ List(last), s"${ss.mkString(", ")} or $last")
+        })
+        .log("(list, expected)")
+    } yield {
+      import extras.strings.syntax.strings._
+
+      val actual = list.commaOr
+      actual ==== expected
+    }
+
 
 }


### PR DESCRIPTION
Close #416 - [`extras-string`] Add `commaOr` syntax for `Seq[String]`