### PR TITLE
Close #417 - [`extras-string`] Add `serialCommaOr` syntax for `Seq[String]`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/strings.scala
@@ -150,6 +150,33 @@ object strings extends strings {
       */
     def commaOr: String = commaWith("or")
 
+    /** Format Seq[String] into a human-readable list using comma and the conjunction `or`.
+      * It separates elements by commas and uses the term `or` before the last element following the "Oxford comma" style. e.g.) "aaa, bbb, or ccc".
+      *
+      * @example
+      * {{{
+      *   List.empty[String].serialCommaOr
+      *   // String = ""
+      *
+      *   List("").serialCommaOr
+      *   // String = ""
+      *
+      *   List("aaa").serialCommaOr
+      *   // String = "aaa"
+      *
+      *   List("aaa", "bbb").serialCommaOr
+      *   // String = "aaa or bbb"
+      *
+      *   List("aaa", "bbb", "ccc").serialCommaOr
+      *   // String = "aaa, bbb, or ccc"
+      *
+      *   List("aaa", "bbb", "ccc", "ddd").serialCommaOr
+      *   // String = "aaa, bbb, ccc, or ddd"
+      *
+      * }}}
+      */
+    def serialCommaOr: String = serialCommaWith("or")
+
   }
 
 }

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -27,6 +27,10 @@ object stringsSpec extends Properties {
     example("test List.empty[String].commaOr", testEmptyListCommaOr),
     example("test List(\"\").commaOr", testListWithSingleEmptyStringCommaOr),
     property("test List[String].commaOr", testCommaOr),
+    //
+    example("test List.empty[String].serialCommaOr", testEmptyListSerialCommaOr),
+    example("test List(\"\").serialCommaOr", testListWithSingleEmptyStringSerialCommaOr),
+    property("test List[String].serialCommaOr", testSerialCommaOr),
   )
 
   def testEmptyListCommaWith: Property = for {
@@ -195,14 +199,13 @@ object stringsSpec extends Properties {
       actual ==== expected
     }
 
-
   ///
 
   def testEmptyListCommaOr: Result = {
     import extras.strings.syntax.strings._
 
     val expected = ""
-    val actual = List.empty[String].commaOr
+    val actual   = List.empty[String].commaOr
     actual ==== expected
   }
 
@@ -210,23 +213,23 @@ object stringsSpec extends Properties {
     import extras.strings.syntax.strings._
 
     val expected = ""
-    val actual = List("").commaOr
+    val actual   = List("").commaOr
     actual ==== expected
   }
 
   def testCommaOr: Property =
     for {
-      ss <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
       last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
 
       (list, expected) <- Gen
-        .constant(ss match {
-          case Nil =>
-            (List(last), last)
-          case _ =>
-            (ss ++ List(last), s"${ss.mkString(", ")} or $last")
-        })
-        .log("(list, expected)")
+                            .constant(ss match {
+                              case Nil =>
+                                (List(last), last)
+                              case _ =>
+                                (ss ++ List(last), s"${ss.mkString(", ")} or $last")
+                            })
+                            .log("(list, expected)")
     } yield {
       import extras.strings.syntax.strings._
 
@@ -234,5 +237,44 @@ object stringsSpec extends Properties {
       actual ==== expected
     }
 
+  ///
+
+  def testEmptyListSerialCommaOr: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List.empty[String].serialCommaOr
+    actual ==== expected
+  }
+
+  def testListWithSingleEmptyStringSerialCommaOr: Result = {
+    import extras.strings.syntax.strings._
+
+    val expected = ""
+    val actual   = List("").serialCommaOr
+    actual ==== expected
+  }
+
+  def testSerialCommaOr: Property =
+    for {
+      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+      (list, expected) <- Gen
+                            .constant(ss match {
+                              case Nil =>
+                                (List(last), last)
+                              case s :: Nil =>
+                                (ss ++ List(last), s"$s or $last")
+                              case _ =>
+                                (ss ++ List(last), s"${ss.mkString(", ")}, or $last")
+                            })
+                            .log("(list, expected)")
+    } yield {
+      import extras.strings.syntax.strings._
+
+      val actual = list.serialCommaOr
+      actual ==== expected
+    }
 
 }


### PR DESCRIPTION
Close #417 - [`extras-string`] Add `serialCommaOr` syntax for `Seq[String]`