### PR TITLE
extras v0.41.0

### DIFF
--- a/changelogs/0.41.0.md
+++ b/changelogs/0.41.0.md
@@ -1,0 +1,260 @@
+## [0.41.0](https://github.com/kevin-lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone42) - 2023-08-27
+
+## New Features
+
+* Add `extras-string` module (#406)
+* [`extras-string`] Add `syntax` for `Int` and add `toOrdinal` (#408)
+  ```scala
+  1.toOrdinal
+  // String = 1st
+  2.toOrdinal
+  // String = 2nd
+  3.toOrdinal
+  // String = 3rd
+  4.toOrdinal
+  // String = 4th
+  ...
+  ```
+  ```scala
+  (1 to 30).map(_.toOrdinal).foreach(println(_))
+  ```
+  ```
+  1st
+  2nd
+  3rd
+  4th
+  5th
+  6th
+  7th
+  8th
+  9th
+  10th
+  11th
+  12th
+  13th
+  14th
+  15th
+  16th
+  17th
+  18th
+  19th
+  20th
+  21st
+  22nd
+  23rd
+  24th
+  25th
+  26th
+  27th
+  28th
+  29th
+  30th
+  ```
+
+* [`extras-string`] Add `syntax` for `Long` and add `toOrdinal` (#409)
+  ```scala
+  1L.toOrdinal
+  // String = 1st
+  2L.toOrdinal
+  // String = 2nd
+  3L.toOrdinal
+  // String = 3rd
+  4L.toOrdinal
+  // String = 4th
+  ...
+  ```
+  ```scala
+  (1L to 30L).map(_.toOrdinal).foreach(println(_))
+  ```
+  ```
+  1st
+  2nd
+  3rd
+  4th
+  5th
+  6th
+  7th
+  8th
+  9th
+  10th
+  11th
+  12th
+  13th
+  14th
+  15th
+  16th
+  17th
+  18th
+  19th
+  20th
+  21st
+  22nd
+  23rd
+  24th
+  25th
+  26th
+  27th
+  28th
+  29th
+  30th
+  ```
+
+* [`extras-string`] Add `commaWith` syntax for `Seq[String]` (#419)
+  
+  An extension method for a `Seq[String]`, providing a way to join the elements with a comma and a given conjunction.
+  
+  It joins `String` values with commas and uses the given conjunction before the last element.
+  ```scala
+  List.empty[String].commaWith("BLAH")
+  // String = ""
+
+  List("").commaWith("BLAH")
+  // String = ""
+
+  List("aaa").commaWith("BLAH")
+  // String = "aaa"
+
+  List("aaa", "bbb").commaWith("BLAH")
+  // String = "aaa BLAH bbb"
+
+  List("aaa", "bbb", "ccc").commaWith("BLAH")
+  // String = "aaa, bbb BLAH ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").commaWith("BLAH")
+  // String = "aaa, bbb, ccc BLAH ddd"
+
+  ```
+
+* [`extras-string`] Add `serialCommaWith` syntax for `Seq[String]` (#420)
+
+  An extension method for a `Seq[String]`, providing a way to join the elements with a serial comma and a given conjunction.
+  
+  It joins `String` values with commas and uses the given conjunction before the last element.
+  
+  This method employs the serial comma (also known as the Oxford comma),
+  which means it always inserts a comma before the conjunction unless there are only two elements.
+  ```scala
+  List.empty[String].serialCommaWith("BLAH")
+  // String = ""
+
+  List("").serialCommaWith("BLAH")
+  // String = ""
+
+  List("aaa").serialCommaWith("BLAH")
+  // String = "aaa"
+
+  List("aaa", "bbb").serialCommaWith("BLAH")
+  // String = "aaa BLAH bbb"
+
+  List("aaa", "bbb", "ccc").serialCommaWith("BLAH")
+  // String = "aaa, bbb, BLAH ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").serialCommaWith("BLAH")
+  // String = "aaa, bbb, ccc, BLAH ddd"
+
+  ```
+
+* [`extras-string`] Add `commaAnd` syntax for `Seq[String]` (#412)
+  
+  Format `Seq[String]` into a human-readable list using comma and the conjunction `and`.
+  It separates elements by commas and uses the term `and` before the last element.
+  ```scala
+  List.empty[String].commaAnd
+  // String = ""
+
+  List("").commaAnd
+  // String = ""
+
+  List("aaa").commaAnd
+  // String = "aaa"
+
+  List("aaa", "bbb").commaAnd
+  // String = "aaa and bbb"
+
+  List("aaa", "bbb", "ccc").commaAnd
+  // String = "aaa, bbb and ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").commaAnd
+  // String = "aaa, bbb, ccc and ddd"
+  ```
+
+* [`extras-string`] Add `serialCommaAnd` syntax for `Seq[String]` (#414)
+
+  Format `Seq[String]` into a human-readable list using comma and the conjunction `and`.
+  
+  It separates elements by commas and uses the term `and` before the last element following the "Oxford comma" style.
+  
+  e.g.) `"aaa, bbb, and ccc"`
+
+  ```scala
+  List.empty[String].serialCommaAnd
+  // String = ""
+
+  List("").serialCommaAnd
+  // String = ""
+
+  List("aaa").serialCommaAnd
+  // String = "aaa"
+
+  List("aaa", "bbb").serialCommaAnd
+  // String = "aaa and bbb"
+
+  List("aaa", "bbb", "ccc").serialCommaAnd
+  // String = "aaa, bbb, and ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").serialCommaAnd
+  // String = "aaa, bbb, ccc, and ddd"
+  ```
+
+* [`extras-string`] Add `commaOr` syntax for `Seq[String]` (#416)
+
+  Format `Seq[String]` into a human-readable list using comma and the conjunction `or`.
+  
+  It separates elements by commas and uses the term `or` before the last element.
+  ```scala
+  List.empty[String].commaOr
+  // String = ""
+
+  List("").commaOr
+  // String = ""
+
+  List("aaa").commaOr
+  // String = "aaa"
+
+  List("aaa", "bbb").commaOr
+  // String = "aaa or bbb"
+
+  List("aaa", "bbb", "ccc").commaOr
+  // String = "aaa, bbb or ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").commaOr
+  // String = "aaa, bbb, ccc or ddd"
+  ```
+
+* [`extras-string`] Add `serialCommaOr` syntax for `Seq[String]` (#417)
+
+  Format `Seq[String]` into a human-readable list using comma and the conjunction `or`.
+   
+  It separates elements by commas and uses the term `or` before the last element following the "Oxford comma" style.
+   
+  e.g.) `"aaa, bbb, or ccc"`
+
+  ```scala
+  List.empty[String].serialCommaOr
+  // String = ""
+
+  List("").serialCommaOr
+  // String = ""
+
+  List("aaa").serialCommaOr
+  // String = "aaa"
+
+  List("aaa", "bbb").serialCommaOr
+  // String = "aaa or bbb"
+
+  List("aaa", "bbb", "ccc").serialCommaOr
+  // String = "aaa, bbb, or ccc"
+
+  List("aaa", "bbb", "ccc", "ddd").serialCommaOr
+  // String = "aaa, bbb, ccc, or ddd"
+  ```


### PR DESCRIPTION
# extras v0.41.0
## [0.41.0](https://github.com/kevin-lee/extras/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone42) - 2023-08-27

## New Features

* Add `extras-string` module (#406)
* [`extras-string`] Add `syntax` for `Int` and add `toOrdinal` (#408)
  ```scala
  1.toOrdinal
  // String = 1st
  2.toOrdinal
  // String = 2nd
  3.toOrdinal
  // String = 3rd
  4.toOrdinal
  // String = 4th
  ...
  ```
  ```scala
  (1 to 30).map(_.toOrdinal).foreach(println(_))
  ```
  ```
  1st
  2nd
  3rd
  4th
  5th
  6th
  7th
  8th
  9th
  10th
  11th
  12th
  13th
  14th
  15th
  16th
  17th
  18th
  19th
  20th
  21st
  22nd
  23rd
  24th
  25th
  26th
  27th
  28th
  29th
  30th
  ```

* [`extras-string`] Add `syntax` for `Long` and add `toOrdinal` (#409)
  ```scala
  1L.toOrdinal
  // String = 1st
  2L.toOrdinal
  // String = 2nd
  3L.toOrdinal
  // String = 3rd
  4L.toOrdinal
  // String = 4th
  ...
  ```
  ```scala
  (1L to 30L).map(_.toOrdinal).foreach(println(_))
  ```
  ```
  1st
  2nd
  3rd
  4th
  5th
  6th
  7th
  8th
  9th
  10th
  11th
  12th
  13th
  14th
  15th
  16th
  17th
  18th
  19th
  20th
  21st
  22nd
  23rd
  24th
  25th
  26th
  27th
  28th
  29th
  30th
  ```

* [`extras-string`] Add `commaWith` syntax for `Seq[String]` (#419)
  
  An extension method for a `Seq[String]`, providing a way to join the elements with a comma and a given conjunction.
  
  It joins `String` values with commas and uses the given conjunction before the last element.
  ```scala
  List.empty[String].commaWith("BLAH")
  // String = ""

  List("").commaWith("BLAH")
  // String = ""

  List("aaa").commaWith("BLAH")
  // String = "aaa"

  List("aaa", "bbb").commaWith("BLAH")
  // String = "aaa BLAH bbb"

  List("aaa", "bbb", "ccc").commaWith("BLAH")
  // String = "aaa, bbb BLAH ccc"

  List("aaa", "bbb", "ccc", "ddd").commaWith("BLAH")
  // String = "aaa, bbb, ccc BLAH ddd"

  ```

* [`extras-string`] Add `serialCommaWith` syntax for `Seq[String]` (#420)

  An extension method for a `Seq[String]`, providing a way to join the elements with a serial comma and a given conjunction.
  
  It joins `String` values with commas and uses the given conjunction before the last element.
  
  This method employs the serial comma (also known as the Oxford comma),
  which means it always inserts a comma before the conjunction unless there are only two elements.
  ```scala
  List.empty[String].serialCommaWith("BLAH")
  // String = ""

  List("").serialCommaWith("BLAH")
  // String = ""

  List("aaa").serialCommaWith("BLAH")
  // String = "aaa"

  List("aaa", "bbb").serialCommaWith("BLAH")
  // String = "aaa BLAH bbb"

  List("aaa", "bbb", "ccc").serialCommaWith("BLAH")
  // String = "aaa, bbb, BLAH ccc"

  List("aaa", "bbb", "ccc", "ddd").serialCommaWith("BLAH")
  // String = "aaa, bbb, ccc, BLAH ddd"

  ```

* [`extras-string`] Add `commaAnd` syntax for `Seq[String]` (#412)
  
  Format `Seq[String]` into a human-readable list using comma and the conjunction `and`.
  It separates elements by commas and uses the term `and` before the last element.
  ```scala
  List.empty[String].commaAnd
  // String = ""

  List("").commaAnd
  // String = ""

  List("aaa").commaAnd
  // String = "aaa"

  List("aaa", "bbb").commaAnd
  // String = "aaa and bbb"

  List("aaa", "bbb", "ccc").commaAnd
  // String = "aaa, bbb and ccc"

  List("aaa", "bbb", "ccc", "ddd").commaAnd
  // String = "aaa, bbb, ccc and ddd"
  ```

* [`extras-string`] Add `serialCommaAnd` syntax for `Seq[String]` (#414)

  Format `Seq[String]` into a human-readable list using comma and the conjunction `and`.
  
  It separates elements by commas and uses the term `and` before the last element following the "Oxford comma" style.
  
  e.g.) `"aaa, bbb, and ccc"`

  ```scala
  List.empty[String].serialCommaAnd
  // String = ""

  List("").serialCommaAnd
  // String = ""

  List("aaa").serialCommaAnd
  // String = "aaa"

  List("aaa", "bbb").serialCommaAnd
  // String = "aaa and bbb"

  List("aaa", "bbb", "ccc").serialCommaAnd
  // String = "aaa, bbb, and ccc"

  List("aaa", "bbb", "ccc", "ddd").serialCommaAnd
  // String = "aaa, bbb, ccc, and ddd"
  ```

* [`extras-string`] Add `commaOr` syntax for `Seq[String]` (#416)

  Format `Seq[String]` into a human-readable list using comma and the conjunction `or`.
  
  It separates elements by commas and uses the term `or` before the last element.
  ```scala
  List.empty[String].commaOr
  // String = ""

  List("").commaOr
  // String = ""

  List("aaa").commaOr
  // String = "aaa"

  List("aaa", "bbb").commaOr
  // String = "aaa or bbb"

  List("aaa", "bbb", "ccc").commaOr
  // String = "aaa, bbb or ccc"

  List("aaa", "bbb", "ccc", "ddd").commaOr
  // String = "aaa, bbb, ccc or ddd"
  ```

* [`extras-string`] Add `serialCommaOr` syntax for `Seq[String]` (#417)

  Format `Seq[String]` into a human-readable list using comma and the conjunction `or`.
   
  It separates elements by commas and uses the term `or` before the last element following the "Oxford comma" style.
   
  e.g.) `"aaa, bbb, or ccc"`

  ```scala
  List.empty[String].serialCommaOr
  // String = ""

  List("").serialCommaOr
  // String = ""

  List("aaa").serialCommaOr
  // String = "aaa"

  List("aaa", "bbb").serialCommaOr
  // String = "aaa or bbb"

  List("aaa", "bbb", "ccc").serialCommaOr
  // String = "aaa, bbb, or ccc"

  List("aaa", "bbb", "ccc", "ddd").serialCommaOr
  // String = "aaa, bbb, ccc, or ddd"
  ```
