### PR TITLE
Update: docs with extras-string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -698,6 +698,23 @@ lazy val docsExtrasScalaIo = docsProject("docs-extras-scala-io", file("docs-gen-
   )
   .settings(noPublish)
 
+lazy val docsExtrasString = docsProject("docs-extras-string", file("docs-gen-tmp/extras-string"))
+  .enablePlugins(MdocPlugin)
+  .settings(
+    mdocIn := file("docs/extras-string"),
+    mdocOut := file("generated-docs/docs/extras-string"),
+    cleanFiles += ((ThisBuild / baseDirectory).value / "generated-docs" / "docs" / "extras-string"),
+    libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
+    libraryDependencies ++= {
+      val latestVersion = getLatestExtrasVersion()
+      List(
+        "io.kevinlee" %% "extras-string" % latestVersion
+      )
+    } ++ List(libs.hedgehogCore, libs.hedgehogRunner),
+    mdocVariables := createMdocVariables(),
+  )
+  .settings(noPublish)
+
 lazy val docsExtrasTypeInfo = docsProject("docs-extras-type-info", file("docs-gen-tmp/extras-type-info"))
   .enablePlugins(MdocPlugin)
   .settings(
@@ -1020,7 +1037,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "docsMdocAll",
-  "; docsExtrasRender/mdoc; docsExtrasCats/mdoc; docsExtrasCirce/mdoc; docsExtrasHedgehog/mdoc; docsExtrasDoobieTools/mdoc; docsExtrasDoobieToolsCe2/mdoc; docsExtrasDoobieToolsCe3/mdoc; docsExtrasRefinement/mdoc; docsExtrasTypeInfo/mdoc; docsExtrasTypeInfoScala2/mdoc; docsExtrasTypeInfoScala3/mdoc; docsExtrasScalaIo/mdoc; docsExtrasFs2/mdoc; docsExtrasFs2V2/mdoc; docsExtrasFs2V3/mdoc; docsExtrasTestingTools/mdoc; docsExtrasTestingToolsCats/mdoc; docsExtrasTestingToolsEffectie/mdoc; docsExtrasConcurrent/mdoc; docsExtrasReflects/mdoc; docs/mdoc",
+  "; docsExtrasRender/mdoc; docsExtrasCats/mdoc; docsExtrasCirce/mdoc; docsExtrasHedgehog/mdoc; docsExtrasDoobieTools/mdoc; docsExtrasDoobieToolsCe2/mdoc; docsExtrasDoobieToolsCe3/mdoc; docsExtrasRefinement/mdoc; docsExtrasTypeInfo/mdoc; docsExtrasTypeInfoScala2/mdoc; docsExtrasTypeInfoScala3/mdoc; docsExtrasScalaIo/mdoc; docsExtrasString/mdoc; docsExtrasFs2/mdoc; docsExtrasFs2V2/mdoc; docsExtrasFs2V3/mdoc; docsExtrasTestingTools/mdoc; docsExtrasTestingToolsCats/mdoc; docsExtrasTestingToolsEffectie/mdoc; docsExtrasConcurrent/mdoc; docsExtrasReflects/mdoc; docs/mdoc",
 )
 
 def easeScalacOptionsForDocs(scalacOptions: Seq[String]): Seq[String] =

--- a/docs/common/intro.md
+++ b/docs/common/intro.md
@@ -44,6 +44,12 @@ Go to [<u>**extras-render**</u>](extras-render)
 "io.kevinlee" %% "extras-render-refined" % "@VERSION@"
 ```
 
+## extras-string
+Go to [<u>**extras-string**</u>](extras-string)
+```scala
+"io.kevinlee" %% "extras-string" % "@VERSION@"
+```
+
 ## extras-cats
 Go to [<u>**extras-cats**</u>](extras-cats)
 ```scala

--- a/docs/extras-circe/_category_.json
+++ b/docs/extras-circe/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Circe",
-  "position": 4,
+  "position": 5,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-concurrent/_category_.json
+++ b/docs/extras-concurrent/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Concurrent",
-  "position": 12,
+  "position": 13,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-doobie-tools/common/_category_.json
+++ b/docs/extras-doobie-tools/common/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Doobie Tools",
-  "position": 6,
+  "position": 7,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-fs2/common/_category_.json
+++ b/docs/extras-fs2/common/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - FS2",
-  "position": 10,
+  "position": 11,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-hedgehog/_category_.json
+++ b/docs/extras-hedgehog/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Hedgehog",
-  "position": 5,
+  "position": 6,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-refinement/_category_.json
+++ b/docs/extras-refinement/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Refinement",
-  "position": 8,
+  "position": 9,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-reflects/_category_.json
+++ b/docs/extras-reflects/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Reflects",
-  "position": 13,
+  "position": 14,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-render/_category_.json
+++ b/docs/extras-render/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - Render",
-  "position": 2,
+  "position": 3,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-scala-io/_category_.json
+++ b/docs/extras-scala-io/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - scala.io",
-  "position": 7,
+  "position": 8,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-string/_category_.json
+++ b/docs/extras-string/_category_.json
@@ -1,6 +1,6 @@
 {
-  "label": "Extras - Cats",
-  "position": 4,
+  "label": "Extras - String",
+  "position": 2,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-string/extras-string.md
+++ b/docs/extras-string/extras-string.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 1
+title: 'Getting Started'
+---
+import DocCardList from '@theme/DocCardList';
+
+## Get `extras-string`
+```scala
+"io.kevinlee" %% "extras-string" % "@VERSION@"
+```
+
+
+## Usage
+
+<DocCardList />

--- a/docs/extras-string/numeric.md
+++ b/docs/extras-string/numeric.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 1
+id: 'numeric'
+title: 'numeric syntax'
+---
+
+## Import `numeric` syntax 
+
+```scala mdoc
+import extras.strings.syntax.numeric._
+```
+
+## `numeric` syntax for `Int`
+
+```scala mdoc
+1.toOrdinal
+2.toOrdinal
+3.toOrdinal
+4.toOrdinal
+```
+
+```scala mdoc
+(1 to 100)
+  .map(_.toOrdinal)
+  .grouped(10)
+  .map(_.mkString(", "))
+  .foreach(println(_))
+```
+
+
+## `numeric` syntax for `Long`
+
+```scala mdoc
+1L.toOrdinal
+2L.toOrdinal
+3L.toOrdinal
+4L.toOrdinal
+```
+
+```scala mdoc
+(1L to 100L)
+  .map(_.toOrdinal)
+  .grouped(10)
+  .map(_.mkString(", "))
+  .foreach(println(_))
+```
+

--- a/docs/extras-testing-tools/common/_category_.json
+++ b/docs/extras-testing-tools/common/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - testing-tools",
-  "position": 11,
+  "position": 12,
   "collapsible": true,
   "collapsed": false
 }

--- a/docs/extras-type-info/_category_.json
+++ b/docs/extras-type-info/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Extras - type-info",
-  "position": 9,
+  "position": 10,
   "collapsible": true,
   "collapsed": false
 }


### PR DESCRIPTION
Update: docs with `extras-string`
- Add docs for `extras-string`
- Update sidebar index for `extras-string` and other module doc pages
- Add `extras-string.md` and `numeric.md`