### PR TITLE
extras v0.42.0

### DIFF
--- a/changelogs/0.42.0.md
+++ b/changelogs/0.42.0.md
@@ -1,0 +1,4 @@
+## [0.42.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone43) - 2023-09-10
+
+## Internal Housekeeping
+* Upgrade effectie to `2.0.0-beta12` (#433)


### PR DESCRIPTION
# extras v0.42.0
## [0.42.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone43) - 2023-09-10

## Internal Housekeeping
* Upgrade effectie to `2.0.0-beta12` (#433)
