### PR TITLE
Close #441 - [`extras-string`] Add `extras.strings.syntax.all` to have all `strings` syntax

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/all.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/all.scala
@@ -1,0 +1,7 @@
+package extras.strings.syntax
+
+/** @author Kevin Lee
+  * @since 2023-10-03
+  */
+trait all extends strings with numeric
+object all extends all

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/allSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/allSpec.scala
@@ -1,0 +1,12 @@
+package extras.strings.syntax
+
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2023-10-03
+  */
+object allSpec extends Properties {
+  override def tests: List[Test] =
+    numericSpec.allNumericSpec(extras.strings.syntax.all).tests ++
+      stringsSpec.allStringsSpec(extras.strings.syntax.all).tests
+}

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/numericSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/numericSpec.scala
@@ -7,9 +7,19 @@ import hedgehog.runner._
   * @since 2023-08-21
   */
 object numericSpec extends Properties {
-  override def tests: List[Test] = intsSpec.tests ++ longsSpec.tests
+  override def tests: List[Test] = new allNumericSpec(extras.strings.syntax.numeric).tests
 
-  object intsSpec {
+  final class allNumericSpec(numeric: extras.strings.syntax.numeric) {
+    def tests: List[Test] =
+      intsSpec(numeric).tests ++ longsSpec(numeric).tests
+  }
+  object allNumericSpec {
+    def apply(numeric: extras.strings.syntax.numeric): allNumericSpec = new allNumericSpec(numeric)
+  }
+
+  final class intsSpec(numeric: extras.strings.syntax.numeric) {
+    import numeric._
+
     def tests: List[Test] = List(
       property("test Int.toOrdinal", testToOrdinal)
     )
@@ -22,15 +32,19 @@ object numericSpec extends Properties {
                           .log("(n, expected)")
         (n, expected) = nAndExpected
       } yield {
-        import extras.strings.syntax.numeric._
 
         val actual = n.toOrdinal
         actual ==== expected
       }
 
   }
+  object intsSpec {
+    def apply(numeric: extras.strings.syntax.numeric): intsSpec = new intsSpec(numeric)
+  }
 
-  object longsSpec {
+  final class longsSpec(numeric: extras.strings.syntax.numeric) {
+    import numeric._
+
     def tests: List[Test] = List(
       property("test Long.toOrdinal", testToOrdinal)
     )
@@ -43,12 +57,14 @@ object numericSpec extends Properties {
                           .log("(n, expected)")
         (n, expected) = nAndExpected
       } yield {
-        import extras.strings.syntax.numeric._
 
         val actual = n.toOrdinal
         actual ==== expected
       }
 
+  }
+  object longsSpec {
+    def apply(numeric: extras.strings.syntax.numeric): longsSpec = new longsSpec(numeric)
   }
 
   def ordinal(n: Long): String = {

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/stringsSpec.scala
@@ -7,280 +7,270 @@ import hedgehog.runner._
   * @since 2023-08-22
   */
 object stringsSpec extends Properties {
-  override def tests: List[Test] = List(
-    property("test List.empty[String].commaWith", testEmptyListCommaWith),
-    property("test List(\"\").commaWith", testListWithSingleEmptyStringCommaWith),
-    property("test List[String].commaWith", testCommaWith),
-    //
-    property("test List.empty[String].serialCommaWith", testEmptyListSerialCommaWith),
-    property("test List(\"\").serialCommaWith", testListWithSingleEmptyStringSerialCommaWith),
-    property("test List[String].serialCommaWith", testSerialCommaWith),
-    //
-    example("test List.empty[String].commaAnd", testEmptyListCommaAnd),
-    example("test List(\"\").commaAnd", testListWithSingleEmptyStringCommaAnd),
-    property("test List[String].commaAnd", testCommaAnd),
-    //
-    example("test List.empty[String].serialCommaAnd", testEmptyListSerialCommaAnd),
-    example("test List(\"\").serialCommaAnd", testListWithSingleEmptyStringSerialCommaAnd),
-    property("test List[String].serialCommaAnd", testSerialCommaAnd),
-    //
-    example("test List.empty[String].commaOr", testEmptyListCommaOr),
-    example("test List(\"\").commaOr", testListWithSingleEmptyStringCommaOr),
-    property("test List[String].commaOr", testCommaOr),
-    //
-    example("test List.empty[String].serialCommaOr", testEmptyListSerialCommaOr),
-    example("test List(\"\").serialCommaOr", testListWithSingleEmptyStringSerialCommaOr),
-    property("test List[String].serialCommaOr", testSerialCommaOr),
-  )
+  override def tests: List[Test] = allStringsSpec(extras.strings.syntax.strings).tests
 
-  def testEmptyListCommaWith: Property = for {
-    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-  } yield {
-    import extras.strings.syntax.strings._
+  final class allStringsSpec(strings: extras.strings.syntax.strings) {
+    import strings._
 
-    val expected = ""
-    val actual   = List.empty[String].commaWith(conjunction)
-    actual ==== expected
-  }
+    def tests: List[Test] = List(
+      property("test List.empty[String].commaWith", testEmptyListCommaWith),
+      property("test List(\"\").commaWith", testListWithSingleEmptyStringCommaWith),
+      property("test List[String].commaWith", testCommaWith),
+      //
+      property("test List.empty[String].serialCommaWith", testEmptyListSerialCommaWith),
+      property("test List(\"\").serialCommaWith", testListWithSingleEmptyStringSerialCommaWith),
+      property("test List[String].serialCommaWith", testSerialCommaWith),
+      //
+      example("test List.empty[String].commaAnd", testEmptyListCommaAnd),
+      example("test List(\"\").commaAnd", testListWithSingleEmptyStringCommaAnd),
+      property("test List[String].commaAnd", testCommaAnd),
+      //
+      example("test List.empty[String].serialCommaAnd", testEmptyListSerialCommaAnd),
+      example("test List(\"\").serialCommaAnd", testListWithSingleEmptyStringSerialCommaAnd),
+      property("test List[String].serialCommaAnd", testSerialCommaAnd),
+      //
+      example("test List.empty[String].commaOr", testEmptyListCommaOr),
+      example("test List(\"\").commaOr", testListWithSingleEmptyStringCommaOr),
+      property("test List[String].commaOr", testCommaOr),
+      //
+      example("test List.empty[String].serialCommaOr", testEmptyListSerialCommaOr),
+      example("test List(\"\").serialCommaOr", testListWithSingleEmptyStringSerialCommaOr),
+      property("test List[String].serialCommaOr", testSerialCommaOr),
+    )
 
-  def testListWithSingleEmptyStringCommaWith: Property = for {
-    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-  } yield {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List("").commaWith(conjunction)
-    actual ==== expected
-  }
-
-  def testCommaWith: Property =
-    for {
+    def testEmptyListCommaWith: Property = for {
       conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-      ss          <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
-
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")} $conjunction $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
     } yield {
-      import extras.strings.syntax.strings._
 
-      val actual = list.commaWith(conjunction)
+      val expected = ""
+      val actual   = List.empty[String].commaWith(conjunction)
       actual ==== expected
     }
 
-  ///
-
-  def testEmptyListSerialCommaWith: Property = for {
-    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-  } yield {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List.empty[String].serialCommaWith(conjunction)
-    actual ==== expected
-  }
-
-  def testListWithSingleEmptyStringSerialCommaWith: Property = for {
-    conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-  } yield {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List("").serialCommaWith(conjunction)
-    actual ==== expected
-  }
-
-  def testSerialCommaWith: Property =
-    for {
+    def testListWithSingleEmptyStringCommaWith: Property = for {
       conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
-      ss          <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
-
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-
-                             case s :: Nil =>
-                               (ss ++ List(last), s"$s $conjunction $last")
-
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")}, $conjunction $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
     } yield {
-      import extras.strings.syntax.strings._
 
-      val actual = list.serialCommaWith(conjunction)
+      val expected = ""
+      val actual   = List("").commaWith(conjunction)
       actual ==== expected
     }
 
-  ///
+    def testCommaWith: Property =
+      for {
+        conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
+        ss          <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
 
-  def testEmptyListCommaAnd: Result = {
-    import extras.strings.syntax.strings._
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")} $conjunction $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
 
-    val expected = ""
-    val actual   = List.empty[String].commaAnd
-    actual ==== expected
-  }
+        val actual = list.commaWith(conjunction)
+        actual ==== expected
+      }
 
-  def testListWithSingleEmptyStringCommaAnd: Result = {
-    import extras.strings.syntax.strings._
+    ///
 
-    val expected = ""
-    val actual   = List("").commaAnd
-    actual ==== expected
-  }
-
-  def testCommaAnd: Property =
-    for {
-      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
-
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")} and $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
+    def testEmptyListSerialCommaWith: Property = for {
+      conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
     } yield {
-      import extras.strings.syntax.strings._
 
-      val actual = list.commaAnd
+      val expected = ""
+      val actual   = List.empty[String].serialCommaWith(conjunction)
       actual ==== expected
     }
 
-  ///
-
-  def testEmptyListSerialCommaAnd: Result = {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List.empty[String].serialCommaAnd
-    actual ==== expected
-  }
-
-  def testListWithSingleEmptyStringSerialCommaAnd: Result = {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List("").serialCommaAnd
-    actual ==== expected
-  }
-
-  def testSerialCommaAnd: Property =
-    for {
-      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
-
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-                             case s :: Nil =>
-                               (ss ++ List(last), s"$s and $last")
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")}, and $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
+    def testListWithSingleEmptyStringSerialCommaWith: Property = for {
+      conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
     } yield {
-      import extras.strings.syntax.strings._
 
-      val actual = list.serialCommaAnd
+      val expected = ""
+      val actual   = List("").serialCommaWith(conjunction)
       actual ==== expected
     }
 
-  ///
+    def testSerialCommaWith: Property =
+      for {
+        conjunction <- Gen.string(Gen.alphaNum, Range.linear(1, 5)).log("conjunction")
+        ss          <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last        <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
 
-  def testEmptyListCommaOr: Result = {
-    import extras.strings.syntax.strings._
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
 
-    val expected = ""
-    val actual   = List.empty[String].commaOr
-    actual ==== expected
-  }
+                               case s :: Nil =>
+                                 (ss ++ List(last), s"$s $conjunction $last")
 
-  def testListWithSingleEmptyStringCommaOr: Result = {
-    import extras.strings.syntax.strings._
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")}, $conjunction $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
 
-    val expected = ""
-    val actual   = List("").commaOr
-    actual ==== expected
-  }
+        val actual = list.serialCommaWith(conjunction)
+        actual ==== expected
+      }
 
-  def testCommaOr: Property =
-    for {
-      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+    ///
 
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")} or $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
-    } yield {
-      import extras.strings.syntax.strings._
+    def testEmptyListCommaAnd: Result = {
 
-      val actual = list.commaOr
+      val expected = ""
+      val actual   = List.empty[String].commaAnd
       actual ==== expected
     }
 
-  ///
+    def testListWithSingleEmptyStringCommaAnd: Result = {
 
-  def testEmptyListSerialCommaOr: Result = {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List.empty[String].serialCommaOr
-    actual ==== expected
-  }
-
-  def testListWithSingleEmptyStringSerialCommaOr: Result = {
-    import extras.strings.syntax.strings._
-
-    val expected = ""
-    val actual   = List("").serialCommaOr
-    actual ==== expected
-  }
-
-  def testSerialCommaOr: Property =
-    for {
-      ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
-      last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
-
-      listAndExpected <- Gen
-                           .constant(ss match {
-                             case Nil =>
-                               (List(last), last)
-                             case s :: Nil =>
-                               (ss ++ List(last), s"$s or $last")
-                             case _ =>
-                               (ss ++ List(last), s"${ss.mkString(", ")}, or $last")
-                           })
-                           .log("(list, expected)")
-      (list, expected) = listAndExpected
-    } yield {
-      import extras.strings.syntax.strings._
-
-      val actual = list.serialCommaOr
+      val expected = ""
+      val actual   = List("").commaAnd
       actual ==== expected
     }
 
+    def testCommaAnd: Property =
+      for {
+        ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")} and $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
+
+        val actual = list.commaAnd
+        actual ==== expected
+      }
+
+    ///
+
+    def testEmptyListSerialCommaAnd: Result = {
+
+      val expected = ""
+      val actual   = List.empty[String].serialCommaAnd
+      actual ==== expected
+    }
+
+    def testListWithSingleEmptyStringSerialCommaAnd: Result = {
+
+      val expected = ""
+      val actual   = List("").serialCommaAnd
+      actual ==== expected
+    }
+
+    def testSerialCommaAnd: Property =
+      for {
+        ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
+                               case s :: Nil =>
+                                 (ss ++ List(last), s"$s and $last")
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")}, and $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
+
+        val actual = list.serialCommaAnd
+        actual ==== expected
+      }
+
+    ///
+
+    def testEmptyListCommaOr: Result = {
+
+      val expected = ""
+      val actual   = List.empty[String].commaOr
+      actual ==== expected
+    }
+
+    def testListWithSingleEmptyStringCommaOr: Result = {
+
+      val expected = ""
+      val actual   = List("").commaOr
+      actual ==== expected
+    }
+
+    def testCommaOr: Property =
+      for {
+        ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")} or $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
+
+        val actual = list.commaOr
+        actual ==== expected
+      }
+
+    ///
+
+    def testEmptyListSerialCommaOr: Result = {
+
+      val expected = ""
+      val actual   = List.empty[String].serialCommaOr
+      actual ==== expected
+    }
+
+    def testListWithSingleEmptyStringSerialCommaOr: Result = {
+
+      val expected = ""
+      val actual   = List("").serialCommaOr
+      actual ==== expected
+    }
+
+    def testSerialCommaOr: Property =
+      for {
+        ss   <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).list(Range.linear(0, 5)).log("ss")
+        last <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("last")
+
+        listAndExpected <- Gen
+                             .constant(ss match {
+                               case Nil =>
+                                 (List(last), last)
+                               case s :: Nil =>
+                                 (ss ++ List(last), s"$s or $last")
+                               case _ =>
+                                 (ss ++ List(last), s"${ss.mkString(", ")}, or $last")
+                             })
+                             .log("(list, expected)")
+        (list, expected) = listAndExpected
+      } yield {
+
+        val actual = list.serialCommaOr
+        actual ==== expected
+      }
+  }
+  object allStringsSpec {
+    def apply(strings: extras.strings.syntax.strings): allStringsSpec = new allStringsSpec(strings)
+  }
 }


### PR DESCRIPTION
Close #441 - [`extras-string`] Add `extras.strings.syntax.all` to have all `strings` syntax