### PR TITLE
Refactor splitByCase to use `(cs: List[Char]) match { case Nil =>`

### DIFF
--- a/modules/extras-string/shared/src/main/scala/extras/strings/syntax/cases.scala
+++ b/modules/extras-string/shared/src/main/scala/extras/strings/syntax/cases.scala
@@ -82,7 +82,7 @@ object cases extends cases {
             acc :+ current.append(last).toString :+ head.toString
 
           case head :: Nil =>
-            acc :+ current.append(last).append(head).toString
+            splitEach(Nil, head, current.append(last), acc)
 
           case head :: tail if last.isUpper && head.isLower =>
             splitEach(

--- a/modules/extras-string/shared/src/test/scala/extras/strings/syntax/casesSpec/stringCaseOpsSpec/SplitByCaseSpec.scala
+++ b/modules/extras-string/shared/src/test/scala/extras/strings/syntax/casesSpec/stringCaseOpsSpec/SplitByCaseSpec.scala
@@ -15,12 +15,28 @@ object SplitByCaseSpec extends Properties {
   import extras.strings.syntax.cases._
 
   override def tests: List[Test] = List(
+    example("test String.SplitByCase with an empty String", testSplitByCaseWithEmptyString),
     property("test String.SplitByCase with PascalCase", testSplitByCaseWithPascalCase),
     property("test String.SplitByCase with PascalCases", testSplitByCaseWithPascalCases),
     property("test String.SplitByCase with camelCases", testSplitByCaseWithCamelCases),
     property("test String.SplitByCase with all UPPERCASE", testSplitByCaseWithUpperCase),
     property("test String.SplitByCase with all lowercase", testSplitByCaseWithLowerCase),
   )
+
+  def testSplitByCaseWithEmptyString: Result = {
+    val input    = ""
+    val expected = Vector.empty[String]
+    val actual   = input.splitByCase
+
+    val info =
+      s"""
+         |>    input: $input
+         |>   actual: ${actual.toString}
+         |> expected: ${expected.toString}
+         |""".stripMargin
+
+    (actual ==== expected).log(info)
+  }
 
   def testSplitByCaseWithPascalCase: Property = for {
     s     <- Gens.genPascalCase(1, 10).log("s")


### PR DESCRIPTION
Refactor splitByCase to use `(cs: List[Char]) match { case Nil =>`
- It was an unreachable case by the old logic.