### PR TITLE
Close #517 - Bump `hedgehog-extra` to `0.8.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1149,7 +1149,7 @@ lazy val props = new {
 
   val HedgehogVersion = "0.9.0"
 
-  val HedgehogExtraVersion = "0.3.0"
+  val HedgehogExtraVersion = "0.8.0"
 
   val NewtypeVersion = "0.4.4"
 


### PR DESCRIPTION
Close #517 - Bump `hedgehog-extra` to `0.8.0`