### PR TITLE
Update docs: Format `Int.toOrdinal` and `Long.toOrdinal` headings

### DIFF
--- a/docs/extras-string/numeric.md
+++ b/docs/extras-string/numeric.md
@@ -16,7 +16,7 @@ import extras.strings.syntax.all._
 
 ## `numeric` syntax for `Int`
 
-### Int.toOrdinal
+### `Int.toOrdinal`
 
 ```scala mdoc
 1.toOrdinal
@@ -36,7 +36,7 @@ import extras.strings.syntax.all._
 
 ## `numeric` syntax for `Long`
 
-### Long.toOrdinal
+### `Long.toOrdinal`
 
 ```scala mdoc
 1L.toOrdinal


### PR DESCRIPTION
Update docs: Format `Int.toOrdinal` and `Long.toOrdinal` headings