### PR TITLE
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.1 / clean up unused build settings related to the old Maven Central (OSSRH).

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,6 @@ ThisBuild / scmInfo :=
 
 ThisBuild / licenses := props.licenses
 
-ThisBuild / resolvers += "sonatype-snapshots".at(
-  s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
-)
-
 ThisBuild / scalafixConfig := (
   if (scalaVersion.value.startsWith("3")) file(".scalafix-scala3.conf").some
   else file(".scalafix-scala2.conf").some
@@ -49,7 +45,6 @@ lazy val extras = (project in file("."))
     name := props.RepoName,
     libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
   )
-  .settings(mavenCentralPublishSettings)
   .settings(noPublish)
   .settings(noDoc)
   .aggregate(
@@ -957,13 +952,6 @@ lazy val docsExtrasTestingToolsEffectie =
 def prefixedProjectName(name: String) = s"${props.RepoName}${if (name.isEmpty) "" else s"-$name"}"
 // scalafmt: on
 
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
-
 def subProject(projectName: String): Project = {
   val prefixedName = prefixedProjectName(projectName)
   Project(projectName, file(s"modules/$prefixedName"))
@@ -979,9 +967,6 @@ def subProject(projectName: String): Project = {
         else
           ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
       ),
-    )
-    .settings(
-      mavenCentralPublishSettings
     )
 }
 
@@ -1027,9 +1012,6 @@ def crossSubProject(projectName: String, crossProject: CrossProject.Builder): Cr
         else
           scalacOptions.value
       },
-    )
-    .settings(
-      mavenCentralPublishSettings
     )
 }
 
@@ -1115,9 +1097,6 @@ lazy val props = new {
 
   val CrossScalaVersions =
     (Scala3Versions ++ Scala2Versions).distinct
-
-  val SonatypeCredentialHost = "s01.oss.sonatype.org"
-  val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
   val CatsVersion      = "2.8.0"
   val Cats2_0_0Version = "2.0.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ import sbt.Defaults.sbtPluginExtra
 logLevel := sbt.Level.Warn
 scalaVersion := "2.12.18"
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.7.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.7")
 


### PR DESCRIPTION
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.1 / clean up unused build settings related to the old Maven Central (OSSRH).

Due to the end-of-life (sunset) of OSSRH, upgrading sbt to 1.11.0 and sbt-ci-release to 1.11.1 was required in order to publish artifacts to the Central Publisher Portal (Maven Central).