### PR TITLE
extras v0.45.0

### DIFF
--- a/changelogs/0.45.0.md
+++ b/changelogs/0.45.0.md
@@ -1,0 +1,8 @@
+## [0.45.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Amilestone46) - 2025-06-23
+
+## Internal Housekeeping
+* Upgrade `effectie` to `2.0.0` (#526)
+* ~~Upgrade `effectie` to `2.0.0-beta14` (#508)~~
+
+## New Features
+* Add Scala.js support (#522)


### PR DESCRIPTION
# extras v0.45.0
## [0.45.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Amilestone46) - 2025-06-23

## Internal Housekeeping
* Upgrade `effectie` to `2.0.0` (#526)
* ~~Upgrade `effectie` to `2.0.0-beta14` (#508)~~

## New Features
* Add Scala.js support (#522)
