### PR TITLE
Upgrade Docusaurus to version 3.8.1 and migrate to TypeScript

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -15,7 +15,7 @@ jobs:
         scala:
           - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "16.16.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -14,7 +14,7 @@ jobs:
         scala:
           - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "16.16.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,16 +1,20 @@
+// @ts-check
+// Note: type annotations allow type checking and IDEs autocompletion
+import {themes as prismThemes} from 'prism-react-renderer';
+import type {Config} from '@docusaurus/types';
+import type * as Preset from '@docusaurus/preset-classic';
+
 const algoliaConfig = require('./algolia.config.json');
 const googleAnalyticsConfig = require('./google-analytics.config.json');
 
-const lightCodeTheme = require('prism-react-renderer/themes/nightOwlLight');
-const darkCodeTheme = require('prism-react-renderer/themes/nightOwl');
+const lightCodeTheme = prismThemes.nightOwlLight;
+const darkCodeTheme = prismThemes.nightOwl;
 
-const isEmptyObject = obj => {
-  for (field in obj) return false;
-  return true;
-};
+const isEmptyObject = (obj: object) => Object.keys(obj).length === 0;
 
 const isSearchable = !isEmptyObject(algoliaConfig);
 const hasGoogleAnalytics = !isEmptyObject(googleAnalyticsConfig);
+
 const gtag = hasGoogleAnalytics ? { 'gtag': googleAnalyticsConfig } : null;
 
 // With JSDoc @type annotations, IDEs can provide config autocompletion

--- a/website/package.json
+++ b/website/package.json
@@ -11,22 +11,23 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@docusaurus/core": "2.3.1",
-    "@docusaurus/preset-classic": "2.3.1",
-    "@mdx-js/react": "^1.6.22",
-    "@svgr/webpack": "^5.5.0",
-    "clsx": "^1.2.1",
-    "file-loader": "^6.2.0",
-    "prism-react-renderer": "^1.3.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "url-loader": "^4.1.1"
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
+    "@mdx-js/react": "^3.0.0",
+    "clsx": "^2.0.0",
+    "prism-react-renderer": "^2.3.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.3.1"
+    "@docusaurus/module-type-aliases": "3.8.1",
+    "@docusaurus/tsconfig": "3.8.1",
+    "@docusaurus/types": "3.8.1",
+    "typescript": "~5.6.2"
   },
   "browserslist": {
     "production": [
@@ -35,12 +36,12 @@
       "not op_mini all"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
     ]
   },
   "engines": {
-    "node": ">=16.14"
+    "node": ">=18.0"
   }
 }


### PR DESCRIPTION
Upgrade Docusaurus to version 3.8.1 and migrate to TypeScript

- Bump Node version to build the doc site to 22.17.0
- Convert docusaurus.config.js to TypeScript (docusaurus.config.ts)
- Update dependencies to latest versions:
  - Docusaurus core and preset-classic from 2.3.1 to 3.8.1
  - React and React DOM to version 19.0.0
  - prism-react-renderer to version 2.3.0
  - Other dependencies updated to compatible versions
- Increase minimum Node.js requirement from 16.14 to 18.0
- Add typecheck script to package.json