### PR TITLE
Update docs: Replace outdated 47deg.com URLs with current xebia.com URLs

### DIFF
--- a/docs/extras-testing-tools/cats/cats.md
+++ b/docs/extras-testing-tools/cats/cats.md
@@ -118,7 +118,7 @@ hello2.hello(Id(1))
 
 :::caution NOTE
 
-Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://www.47deg.com/blog/mocking-and-how-to-avoid-it) from [Xebia Functional](https://www.47deg.com) (formerly known as 47 Degrees)
+Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://xebia.com/blog/pitfalls-mocking-tests-how-to-avoid) from [Xebia Functional](https://xebia.com) (formerly known as 47 Degrees)
 
 Besides what the blog tells you, mock frameworks often make you do bad practice like testing the implementation details with `verify`.
 

--- a/docs/extras-testing-tools/common/testing-tools.md
+++ b/docs/extras-testing-tools/common/testing-tools.md
@@ -75,7 +75,7 @@ println(hello2.hello(Id(1)))
 
 :::caution NOTE
 
-Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://www.47deg.com/blog/mocking-and-how-to-avoid-it) from [Xebia Functional](https://www.47deg.com) (formerly known as 47 Degrees)
+Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://xebia.com/blog/pitfalls-mocking-tests-how-to-avoid) from [Xebia Functional](https://xebia.com) (formerly known as 47 Degrees)
 
 Besides what the blog tells you, mock frameworks often make you do bad practice like testing the implementation details with `verify`.
 

--- a/docs/extras-testing-tools/effectie/effectie.md
+++ b/docs/extras-testing-tools/effectie/effectie.md
@@ -125,7 +125,7 @@ hello2.hello(Id(1))
 
 :::caution NOTE
 
-Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://www.47deg.com/blog/mocking-and-how-to-avoid-it) from [Xebia Functional](https://www.47deg.com) (formerly known as 47 Degrees)
+Why not just use mock framework for convenience? To answer that, please read [Pitfalls of Mocking in tests](https://xebia.com/blog/pitfalls-mocking-tests-how-to-avoid) from [Xebia Functional](https://xebia.com) (formerly known as 47 Degrees)
 
 Besides what the blog tells you, mock frameworks often make you do bad practice like testing the implementation details with `verify`.
 


### PR DESCRIPTION
Update docs: Replace outdated 47deg.com URLs with current xebia.com URLs in testing tools documentation across cats, common, and effectie modules.