### PR TITLE
Close #545: [`extras-render`] Provide an optional instance of `cats.Contravariant[Render]`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,6 +277,11 @@ lazy val extrasFs2V3TextJs  = extrasFs2V3Text.js.settings(Test / fork := false)
 lazy val extrasRender    = crossSubProject("render", crossProject(JVMPlatform, JSPlatform))
   .settings(
     crossScalaVersions := props.CrossScalaVersions,
+    libraryDependencies ++= List(
+      libs.cats.value % Optional
+    ) ++ (
+      if (isScala3(scalaVersion.value)) List.empty else List(libs.scalacCompatAnnotation)
+    ),
     libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
   )
 lazy val extrasRenderJvm = extrasRender.jvm
@@ -680,7 +685,7 @@ lazy val docsExtrasHedgehog = docsProject("docs-extras-hedgehog", file("docs-gen
     cleanFiles += ((ThisBuild / baseDirectory).value / "generated-docs" / "docs" / "extras-hedgehog"),
     libraryDependencies := removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
     libraryDependencies ++= {
-      val latestVersion = getLatestExtrasVersion()
+      val latestVersion   = getLatestExtrasVersion()
       List(
         "io.kevinlee" %% "extras-hedgehog-ce3"   % latestVersion,
         "io.kevinlee" %% "extras-hedgehog-circe" % latestVersion,
@@ -1175,6 +1180,8 @@ lazy val props = new {
 
   val ScalaJsMacrotaskExecutorVersion = "1.1.1"
 
+  val ScalacCompatAnnotationVersion = "0.1.4"
+
   val MunitVersion = "0.7.29"
 
   val isScala3Incompatible: ModuleID => Boolean =
@@ -1229,6 +1236,8 @@ lazy val libs = new {
   lazy val hedgehogCore   = Def.setting("qa.hedgehog" %%% "hedgehog-core" % props.HedgehogVersion)
   lazy val hedgehogRunner = Def.setting("qa.hedgehog" %%% "hedgehog-runner" % props.HedgehogVersion)
   lazy val hedgehogSbt    = Def.setting("qa.hedgehog" %%% "hedgehog-sbt" % props.HedgehogVersion)
+
+  lazy val scalacCompatAnnotation = "org.typelevel" %% "scalac-compat-annotation" % props.ScalacCompatAnnotationVersion
 
   lazy val hedgehogExtraCore    = Def.setting("io.kevinlee" %%% "hedgehog-extra-core" % props.HedgehogExtraVersion)
   lazy val hedgehogExtraRefined = Def.setting("io.kevinlee" %%% "hedgehog-extra-refined" % props.HedgehogExtraVersion)

--- a/modules/extras-render/shared/src/main/scala-2/extras/render/Render.scala
+++ b/modules/extras-render/shared/src/main/scala-2/extras/render/Render.scala
@@ -1,6 +1,8 @@
 package extras.render
 
 import java.util.UUID
+import scala.annotation.implicitNotFound
+import org.typelevel.scalaccompat.annotation.nowarn213
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /** @author Kevin Lee
@@ -55,4 +57,26 @@ object Render {
   final case class RenderInterpolator(stringContext: StringContext) extends AnyVal {
     def render(args: Rendered*): String = stringContext.s(args: _*)
   }
+
+  @implicitNotFound(msg =
+    "Missing an instance of `CatsContravariant` which means you're trying to use cats.Contravariant, " +
+      "but cats library is missing in your project config. " +
+      "If you want to have an instance of cats.Contravariant[Render] provided by extras, " +
+      """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
+  )
+  sealed private[Render] trait CatsContravariant[M[_[_]]]
+  private[Render] object CatsContravariant {
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    @inline implicit final def getCatsContravariant: CatsContravariant[cats.Contravariant] =
+      null // scalafix:ok DisableSyntax.null
+  }
+
+  @nowarn213(
+    "msg=evidence parameter evidence\\$.+ of type (.+\\.)+CatsContravariant\\[F\\] in method renderContravariant is never used"
+  )
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def renderContravariant[F[_[_]]: CatsContravariant]: F[Render] =
+    new cats.Contravariant[Render] {
+      override def contramap[A, B](fa: Render[A])(f: B => A): Render[B] = b => fa.render(f(b))
+    }.asInstanceOf[F[Render]] // scalafix:ok DisableSyntax.asInstanceOf
 }

--- a/modules/extras-render/shared/src/test/scala/extras/render/RenderSpec.scala
+++ b/modules/extras-render/shared/src/test/scala/extras/render/RenderSpec.scala
@@ -29,6 +29,12 @@ object RenderSpec extends Properties {
     property("test Render[A].contramap[B] (1)", testRenderContramap1),
     property("test Render[A].contramap[B] (2)", testRenderContramap2),
     property("test Render[A].contramap[B] (3)", testRenderContramap3),
+    property("test Contravariant[Render].contramap[A, B] (1)", testContravariantRenderContramap1),
+    property("test Contravariant[Render].contramap[A, B] (2)", testContravariantRenderContramap2),
+    property("test Contravariant[Render].contramap[A, B] (3)", testContravariantRenderContramap3),
+    property("test Render[A].contramap[B] with cats.syntax (1)", testContravariantRenderContramapWithCatsSyntax1),
+    property("test Render[A].contramap[B] with cats.syntax (2)", testContravariantRenderContramapWithCatsSyntax2),
+    property("test Render[A].contramap[B] with cats.syntax (3)", testContravariantRenderContramapWithCatsSyntax3),
   )
 
   def testRenderRenderA: Property =
@@ -203,6 +209,89 @@ object RenderSpec extends Properties {
 
       val renderId: Render[Id] = Render[String].contramap(_.value)
       renderId.render(id) ==== s
+    }
+
+  def testContravariantRenderContramap1: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      final case class Id(value: UUID)
+      val id = Id(uuid)
+
+      val renderId: Render[Id] = cats.Contravariant[Render].contramap(Render[UUID])(_.value)
+
+      (renderId.render(id) ==== uuid.toString)
+        .log("Contravariant[Render].contramap[UUID, Id](Render[UUID])(Id => UUID) didn't work")
+
+    }
+
+  def testContravariantRenderContramap2: Property =
+    for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      final case class Id(value: Int)
+      val id = Id(n)
+
+      val renderId: Render[Id] = cats.Contravariant[Render].contramap(Render[Int])(_.value)
+
+      (renderId.render(id) ==== n.toString)
+        .log("Contravariant[Render].contramap[Int, Id](Render[Int])(Id => Int) didn't work")
+    }
+
+  def testContravariantRenderContramap3: Property =
+    for {
+      s <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).log("s")
+    } yield {
+      final case class Id(value: String)
+      val id = Id(s)
+
+      val renderId: Render[Id] = cats.Contravariant[Render].contramap(Render[String])(_.value)
+
+      (renderId.render(id) ==== s)
+        .log("Contravariant[Render].contramap[String, Id](Render[String])(Id => String) didn't work")
+    }
+
+  def testContravariantRenderContramapWithCatsSyntax1: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      final case class Id(value: UUID)
+      val id = Id(uuid)
+
+      import cats.syntax.all._
+
+      val renderId: Render[Id] = Render[UUID].contramap(_.value)
+
+      (renderId.render(id) ==== uuid.toString)
+        .log("Render[UUID].contramap[Id](Id => UUID) didn't work")
+    }
+
+  def testContravariantRenderContramapWithCatsSyntax2: Property =
+    for {
+      n <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n")
+    } yield {
+      final case class Id(value: Int)
+      val id = Id(n)
+
+      import cats.syntax.all._
+
+      val renderId: Render[Id] = Render[Int].contramap(_.value)
+
+      (renderId.render(id) ==== n.toString).log("Render[Int].contramap[Id](Id => Int) didn't work")
+    }
+
+  def testContravariantRenderContramapWithCatsSyntax3: Property =
+    for {
+      s <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).log("s")
+    } yield {
+      final case class Id(value: String)
+      val id = Id(s)
+
+      import cats.syntax.all._
+
+      val renderId: Render[Id] = Render[String].contramap(_.value)
+
+      (renderId.render(id) ==== s).log("Render[String].contramap[Id](Id => String) didn't work")
     }
 
 }


### PR DESCRIPTION
Close #545: [`extras-render`] Provide an optional instance of `cats.Contravariant[Render]`

- Implement `CatsContravariant` trait with conditional instance provision
- Add an optional `Contravariant[Render]` type-class instance for Scala 2 and Scala 3
- Include comprehensive test coverage for `Contravariant` operations
- Support both direct `Contravariant` usage and `cats.syntax` integration
- Add `scalac-compat-annotation` dependency for cross-version compatibility in `@nowarn`