### PR TITLE
Update Scala version from 2.13.10 to 2.13.12 in GitHub Actions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala", version: "2.13.10", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala", version: "2.13.12", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
           - { version: "22.17.0" }
 

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.13.10", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
+          - { version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin" }
         node:
           - { version: "22.17.0" }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 2", version: "2.13.10", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 2", version: "2.13.12", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sbt-build-all-with-scala-version.sh
+++ b/.github/workflows/sbt-build-all-with-scala-version.sh
@@ -5,7 +5,7 @@ set -x
 if [ -z "$1" ]
   then
     echo "Missing parameters. Please enter the [Scala version]."
-    echo "sbt-build-all.sh 2.13.10"
+    echo "sbt-build-all.sh 2.13.12"
     exit 1
 else
   : ${CURRENT_BRANCH_NAME:?"CURRENT_BRANCH_NAME is missing."}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.7")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.10")
 addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.2")
 addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.17.0")
 


### PR DESCRIPTION
## Update Scala version from 2.13.10 to 2.13.12 in GitHub Actions config

- Update build matrix in GitHub workflows (build, doc-site-build-only, doc-site-publish, release)
- Update example version in sbt-build-all-with-scala-version.sh help text