### PR TITLE
Update GitHub Actions: Refactor GitHub workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 name: Build-All
 
 on:
-  push:
-    branches-ignore:
-      - main
+  workflow_dispatch:
 
   pull_request:
     branches:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,7 @@
 name: Check-All
 
 on:
-  push:
-    branches:
-      - "**"
+  workflow_dispatch:
 
   pull_request:
     branches:

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -3,7 +3,11 @@ name: "[Doc][A] Build Only"
 on:
   push:
     branches:
-      - "**"
+      - main
+
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-docusaurus:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main


### PR DESCRIPTION
Update GitHub Actions: Refactor GitHub workflow triggers

- Change Build-All workflow from push-triggered (except main) to manual dispatch only
- Change Check-All workflow from all-branch push triggers to manual dispatch only
- Update doc-site build to trigger on `main` branch pushes and PRs instead of all branches
- Add manual dispatch option to Release workflow while keeping main branch push trigger
- Keep pull request trigger unchanged