### PR TITLE
Close #549: Upgrade `hedgehog` and `hedgehog-extra`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1163,9 +1163,9 @@ lazy val props = new {
   val Http4s_0_22_Version = "0.22.15"
   val Http4s_0_23_Version = "0.23.16"
 
-  val HedgehogVersion = "0.9.0"
+  val HedgehogVersion = "0.10.1"
 
-  val HedgehogExtraVersion = "0.8.0"
+  val HedgehogExtraVersion = "0.11.0"
 
   val NewtypeVersion = "0.4.4"
 


### PR DESCRIPTION
## Close #549: Upgrade `hedgehog` and `hedgehog-extra`

- Upgrade `hedgehog` from `0.9.0` to `0.10.1`
- Upgrade `hedgehog-extra` from `0.8.0` to `0.11.0`