### PR TITLE
Update: GitHub Actions - Increase JVM heap size to 8G and consolidate coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=2G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
 
 jobs:
 
@@ -65,41 +65,3 @@ jobs:
           echo "JVM_OPTS=${JVM_OPTS}"
           echo "SBT_OPTS=${SBT_OPTS}"
           .github/workflows/sbt-build-all.sh ${{ matrix.scala.report }}
-
-  report:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - { name: "Scala", version: "2.13.12", java-version: "11", java-distribution: "temurin", report: "report" }
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.scala.java-version }}
-          distribution: ${{ matrix.scala.java-distribution }}
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
-
-      - name: "[PR] Test Report for PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
-        if: github.event_name == 'pull_request'
-        env:
-          CURRENT_BRANCH_NAME: ${{ github.base_ref }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_NUMBER: ${{ github.run_number }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
-        run: |
-          echo "Rull request to the '${CURRENT_BRANCH_NAME}' branch"
-          echo "RUN_ID=${RUN_ID}"
-          echo "RUN_NUMBER=${RUN_NUMBER}"
-          echo "PR #${PR_NUMBER}"
-          java -version
-          echo "JVM_OPTS=${JVM_OPTS}"
-          echo "SBT_OPTS=${SBT_OPTS}"
-          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }} ${{ matrix.scala.report }}
-
-      - if: ${{ github.event_name == 'pull_request' && matrix.scala.report == 'report' }}
-        uses: codecov/codecov-action@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=2G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
 
 jobs:
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,74 @@
+name: "Test Coverage"
+
+on:
+  push:
+    branches:
+      - 'main'
+
+  pull_request:
+    branches:
+      - main
+
+env:
+  GH_SBT_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        scala:
+          - { name: "Scala 2.13", version: "2.13.12", binary-version: "2.13", java-version: "11", java-distribution: "temurin", report: "report" }
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4.7.1
+        with:
+          java-version: ${{ matrix.scala.java-version }}
+          distribution: ${{ matrix.scala.java-distribution }}
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+
+      - name: "[Codecov] Report ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
+        if: ${{ matrix.scala.report == 'report' && github.event_name == 'push' }}
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "[BEFORE]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          export CURRENT_BRANCH_NAME="${CURRENT_BRANCH_NAME#refs/heads/}"
+          echo " [AFTER]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "Push #${PUSH_NUMBER}"
+          java -version
+          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }} ${{ matrix.scala.report }}
+
+
+      - name: "[Codecov] Report ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }} - PR-#${{ github.event.pull_request.number }} - ${{ github.run_number }}"
+        if: ${{ matrix.scala.report == 'report' && github.event_name == 'pull_request' }}
+        env:
+          CURRENT_BRANCH_NAME: ${{ github.base_ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          JVM_OPTS: ${{ env.GH_JVM_OPTS }}
+          SBT_OPTS: ${{ env.GH_SBT_OPTS }}
+        run: |
+          echo "Rull request to the '${CURRENT_BRANCH_NAME}' branch"
+          echo "RUN_ID=${RUN_ID}"
+          echo "RUN_NUMBER=${RUN_NUMBER}"
+          echo "PR #${PR_NUMBER}"
+          java -version
+          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }} ${{ matrix.scala.report }}
+
+      - if: ${{ matrix.scala.report == 'report' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 env:
   GH_JAVA_VERSION: "11"
   GH_JAVA_DISTRIBUTION: "temurin"
-  GH_JVM_OPTS: "-Xss64m -Xms1024m -XX:MaxMetaspaceSize=2G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
 
 
 jobs:
@@ -55,40 +55,6 @@ jobs:
             -v \
             clean \
             +test
-
-  report:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - { name: "Scala 2", version: "2.13.12", java-version: "11", java-distribution: "temurin", report: "report" }
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.scala.java-version }}
-          distribution: ${{ matrix.scala.java-distribution }}
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
-
-      - name: "[Codecov] Test Report - ${{ matrix.scala.name }} ${{ matrix.scala.version }} - ${{ github.run_number }}"
-        if: ${{ matrix.scala.report == 'report' }}
-        env:
-          CURRENT_BRANCH_NAME: ${{ github.ref }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          echo "[BEFORE]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
-          export CURRENT_BRANCH_NAME="${CURRENT_BRANCH_NAME#refs/heads/}"
-          echo " [AFTER]CURRENT_BRANCH_NAME=${CURRENT_BRANCH_NAME}"
-          echo "RUN_ID=${RUN_ID}"
-          echo "RUN_NUMBER=${RUN_NUMBER}"
-          .github/workflows/sbt-build-all-with-scala-version.sh ${{ matrix.scala.version }} ${{ matrix.scala.report }}
-
-      - if: ${{ matrix.scala.report == 'report' }}
-        uses: codecov/codecov-action@v5
 
   gh-release:
     needs: build


### PR DESCRIPTION
Update: GitHub Actions - Increase JVM heap size to 8G and consolidate coverage reporting

- Increase `-Xmx` from `4G` to `8G` in all GitHub workflow files to improve build performance
- Remove duplicate report jobs from `build.yml` and `release.yml` workflows
- Create dedicated `coverage.yml` workflow for centralized test coverage reporting => Consolidate Codecov integration into single workflow for better maintainability