### PR TITLE
Update: GitHub Actions - Add manual trigger to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,8 @@
 name: "Test Coverage"
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - 'main'


### PR DESCRIPTION
Update: GitHub Actions - Add manual trigger to coverage workflow

Enable `workflow_dispatch` for the `coverage.yml` GitHub Actions workflow to allow manual execution of test coverage runs.