### PR TITLE
extras v0.46.0

### DIFF
--- a/changelogs/0.46.0.md
+++ b/changelogs/0.46.0.md
@@ -1,0 +1,20 @@
+## [0.46.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Amilestone47) - 2025-07-27
+
+## New Features
+* [`extras-render`] Add a new implementation of `Render` for Scala 3 using Scala 3 syntax (#543)
+  * Get rid of `implicit` syntax
+    * Use `using` and `summon`.
+    * Use type-class syntax.
+    * Use `extension` method syntax.
+  * Use `opaque type`.
+
+* [`extras-render`] Provide an optional instance of `cats.Contravariant[Render]` (#545)
+  * The instance of `cats.Contravariant[Render]` is available only if the `cats` library is included in the project. Without it, attempting to use or access the instance of the `cats.Contravariant[Render]` type class causes a "**compile-time**" error.
+  * Although `Render` has a `contramap` extension method, it’s still a good idea to provide an instance of `cats.Contravariant`. Since I don’t want `extras-render` to depend on Cats by default, I want to make it optional using sbt’s `Optional` dependency feature.
+
+
+## Internal Housekeeping
+
+* Upgrade `hedgehog` and `hedgehog-extra` (#549)
+  * `hedgehog` to `0.10.1`
+  * `hedgehog-extra` to `0.11.0`


### PR DESCRIPTION
# extras v0.46.0
## [0.46.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Amilestone47) - 2025-07-27

## New Features
* [`extras-render`] Add a new implementation of `Render` for Scala 3 using Scala 3 syntax (#543)
  * Get rid of `implicit` syntax
    * Use `using` and `summon`.
    * Use type-class syntax.
    * Use `extension` method syntax.
  * Use `opaque type`.

* [`extras-render`] Provide an optional instance of `cats.Contravariant[Render]` (#545)
  * The instance of `cats.Contravariant[Render]` is available only if the `cats` library is included in the project. Without it, attempting to use or access the instance of the `cats.Contravariant[Render]` type class causes a "**compile-time**" error.
  * Although `Render` has a `contramap` extension method, it’s still a good idea to provide an instance of `cats.Contravariant`. Since I don’t want `extras-render` to depend on Cats by default, I want to make it optional using sbt’s `Optional` dependency feature.


## Internal Housekeeping

* Upgrade `hedgehog` and `hedgehog-extra` (#549)
  * `hedgehog` to `0.10.1`
  * `hedgehog-extra` to `0.11.0`
