### PR TITLE
Fix #554: [`extras-render`] `.render` `extension` method doesn't work well when there's a method with the same name exists in the context in Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1001,6 +1001,7 @@ def subProject(projectName: String): Project = {
     .settings(
       name := prefixedName,
       Test / fork := true,
+      scalacOptions += "-explain",
       libraryDependencies ++= libs.hedgehog.value,
       testFrameworks ~=
         (frameworks => (TestFramework("hedgehog.sbt.Framework") +: frameworks).distinct),
@@ -1133,6 +1134,7 @@ lazy val props = new {
   val Scala2Version  = Scala2Versions.head
 
   val Scala3Versions = List("3.1.3")
+//  val Scala3Versions = List("3.3.6")
   val Scala3Version  = Scala3Versions.head
 
   val ProjectScalaVersion = Scala2Version
@@ -1296,7 +1298,7 @@ def scalacOptionsPostProcess(scalaVersion: String, options: Seq[String]): Seq[St
   if (scalaVersion.startsWith("3.")) {
     scala3cLanguageOptions ++
       options.filterNot(o =>
-        o == "-language:dynamics,existentials,higherKinds,reflectiveCalls,experimental.macros,implicitConversions" || o == "UTF-8",
+        o == "-language:dynamics,existentials,higherKinds,reflectiveCalls,experimental.macros,implicitConversions" || o == "UTF-8"
       )
   } else {
     options.filterNot(_ == "UTF-8")

--- a/modules/extras-render/shared/src/main/scala-3/extras/render/Render.scala
+++ b/modules/extras-render/shared/src/main/scala-3/extras/render/Render.scala
@@ -57,7 +57,7 @@ object Render {
     given toRendered[A](using R: Render[A]): Conversion[A, Rendered] = a => apply(R.render(a))
 
     extension (rendered: Rendered) {
-      inline def toString: String = rendered
+      inline def value: String = rendered
     }
   }
 

--- a/modules/extras-render/shared/src/main/scala-3/extras/render/syntax.scala
+++ b/modules/extras-render/shared/src/main/scala-3/extras/render/syntax.scala
@@ -9,12 +9,22 @@ import scala.collection.mutable
   * @since 2022-10-15
   */
 trait syntax {
+  import syntax.*
 
-  extension [A](a: A) {
-    def render(using R: Render[A]): String = R.render(a)
+  implicit def renderSyntaxA[A](a: A): RenderSyntaxA[A] = new RenderSyntaxA[A](a)
+
+  implicit def renderSyntaxIterable[A](as: Iterable[A]): RenderSyntaxIterable[A] = new RenderSyntaxIterable[A](as)
+
+  extension (stringContext: StringContext) {
+    def render(args: Rendered*): String = stringContext.s(args*)
+  }
+}
+object syntax extends syntax {
+  final class RenderSyntaxA[A](private val a: A) extends AnyVal {
+    def render(implicit R: Render[A]): String = R.render(a)
   }
 
-  extension [A](as: Iterable[A]) {
+  final class RenderSyntaxIterable[A](private val as: Iterable[A]) extends AnyVal {
     /* WARNING: This method uses mutable data structure internally for performance */
     @SuppressWarnings(
       Array(
@@ -62,8 +72,4 @@ trait syntax {
       renderString("")
   }
 
-  extension (stringContext: StringContext) {
-    def render(args: Rendered*): String = stringContext.s(args: _*)
-  }
 }
-object syntax extends syntax

--- a/modules/extras-render/shared/src/test/scala-2/extras/render/ScalaVersionSpecificSyntaxSpec.scala
+++ b/modules/extras-render/shared/src/test/scala-2/extras/render/ScalaVersionSpecificSyntaxSpec.scala
@@ -1,0 +1,101 @@
+package extras.render
+
+import hedgehog._
+import hedgehog.runner._
+
+import extras.render.syntax._
+
+/** @author Kevin Lee
+  * @since 2025-07-27
+  */
+trait ScalaVersionSpecificSyntaxSpec extends Properties {
+  import ScalaVersionSpecificSyntaxSpec._
+
+  val scalaVersionSpecificTests: List[Test] = List(
+    property("test MyOwnType.render", testMyOwnTypeRender),
+    property("test MyOwnTypeWithAdt.render", testMyOwnTypeWithAdtRender),
+    property("test MyOwnTypeInsideCaseClass.render", testMyOwnTypeInsideCaseClassRender),
+  )
+
+  def testMyOwnTypeRender: Property =
+    for {
+      s <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).map(Name(_)).log("s")
+    } yield {
+      s.render ==== s.value
+    }
+
+  def testMyOwnTypeWithAdtRender: Property =
+    for {
+      n     <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+      s     <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).log("s")
+      myAdt <-
+        Gen.element1(MyAdt.caseA(n), MyAdt.caseB(s), MyAdt.caseC).log("myAdt")
+    } yield {
+      myAdt.render ==== (myAdt match {
+        case MyAdt.CaseA(n) => n.toString
+        case MyAdt.CaseB(name) => name
+        case MyAdt.CaseC => "CaseC"
+      })
+    }
+
+  def testMyOwnTypeInsideCaseClassRender: Property =
+    for {
+      something <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).map(MyOwnCaseClass.Something(_)).log("something")
+      myOwnCaseClass <- Gen.constant(MyOwnCaseClass(something)).log("myOwnCaseClass")
+    } yield {
+      myOwnCaseClass.render ==== s"MyOwnCaseClass(something=${myOwnCaseClass.something.value})"
+    }
+
+}
+object ScalaVersionSpecificSyntaxSpec {
+  final case class Name(value: String) extends AnyVal
+  object Name {
+    implicit val renderName: Render[Name] = _.value
+  }
+
+  sealed trait MyAdt
+  object MyAdt {
+
+    final case class CaseA(n: Int) extends MyAdt
+    final case class CaseB(name: String) extends MyAdt
+    case object CaseC extends MyAdt
+
+    def caseA(n: Int): MyAdt       = CaseA(n)
+    def caseB(name: String): MyAdt = CaseB(name)
+    def caseC: MyAdt               = CaseC
+
+    implicit val renderMyAdt: Render[MyAdt] = new Render[MyAdt] {
+      override def render(a: MyAdt): String = a match {
+        case CaseA(n) => n.render
+        case CaseB(name) => name.render
+        case CaseC => "CaseC"
+      }
+    }
+  }
+
+  final case class MyOwnCaseClass(
+    something: MyOwnCaseClass.Something
+  )
+  object MyOwnCaseClass {
+
+    implicit val renderMyOwnCaseClass: Render[MyOwnCaseClass] = new Render[MyOwnCaseClass] {
+      override def render(a: MyOwnCaseClass): String =
+        s"MyOwnCaseClass(something=${a.something.render})"
+    }
+
+    /* This doesn't work with the existing render from the extension method of A using Render[A]
+     */
+//    extension (myOwnCaseClass: MyOwnCaseClass) {
+//      def render: String = s"MyOwnCaseClass(something=${myOwnCaseClass.something.render})"
+//    }
+
+    final case class Something(value: String) extends AnyVal
+    object Something {
+      implicit val renderSomething: Render[Something] = new Render[Something] {
+        override def render(a: Something): String = a.value
+      }
+    }
+
+  }
+
+}

--- a/modules/extras-render/shared/src/test/scala-3/extras/render/ScalaVersionSpecificSyntaxSpec.scala
+++ b/modules/extras-render/shared/src/test/scala-3/extras/render/ScalaVersionSpecificSyntaxSpec.scala
@@ -1,0 +1,124 @@
+package extras.render
+
+import hedgehog.*
+import hedgehog.runner.*
+
+import extras.render.syntax.*
+
+/** @author Kevin Lee
+  * @since 2025-07-27
+  */
+trait ScalaVersionSpecificSyntaxSpec extends Properties {
+  import ScalaVersionSpecificSyntaxSpec.*
+
+  val scalaVersionSpecificTests: List[Test] = List(
+    property("test MyOwnType.render", testMyOwnTypeRender),
+    property("test MyOwnTypeWithUnionType.render", testMyOwnTypeWithUnionTypeRender),
+    property("test MyOwnTypeInsideCaseClass.render", testMyOwnTypeInsideCaseClassRender),
+  )
+
+  def testMyOwnTypeRender: Property =
+    for {
+      s <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).map(Name(_)).log("s")
+    } yield {
+      s.render ==== s
+    }
+
+  def testMyOwnTypeWithUnionTypeRender: Property =
+    for {
+      n           <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+      s           <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).log("s")
+      myUnionType <-
+        Gen.element1[CaseA | CaseB | CaseC.type](CaseA(n), CaseB(s), CaseC).map(MyUnionType(_)).log("myUnionType")
+    } yield {
+      myUnionType.render ==== (myUnionType.value match {
+        case CaseA(n) => n.toString
+        case CaseB(name) => name
+        case CaseC => "CaseC"
+      })
+    }
+
+  def testMyOwnTypeInsideCaseClassRender: Property =
+    for {
+      something <- Gen.string(Gen.unicodeAll, Range.linear(1, 100)).map(MyOwnCaseClass.Something(_)).log("something")
+      myOwnCaseClass <- Gen.constant(MyOwnCaseClass(something)).log("myOwnCaseClass")
+    } yield {
+      myOwnCaseClass.render ==== s"MyOwnCaseClass(something=${myOwnCaseClass.something.value})"
+    }
+
+}
+object ScalaVersionSpecificSyntaxSpec {
+  type Name = Name.Type
+  object Name {
+    opaque type Type = String
+    def apply(name: String): Name = name
+
+    given nameCanEqual: CanEqual[Name, Name] = CanEqual.derived
+
+    extension (name: Name) {
+      def value: String = name
+    }
+
+    given RenderName: Render[Name] = _.value
+
+  }
+
+  final case class CaseA(n: Int)
+  final case class CaseB(name: String)
+  case object CaseC
+
+  type MyUnionType = MyUnionType.Type
+  object MyUnionType {
+    opaque type Type = CaseA | CaseB | CaseC.type
+    def apply(myUnionType: CaseA | CaseB | CaseC.type): MyUnionType = myUnionType
+
+    given myUnionTypeCanEqual: CanEqual[MyUnionType, MyUnionType] = CanEqual.derived
+
+    extension (myUnionType: MyUnionType) {
+      def value: CaseA | CaseB | CaseC.type = myUnionType
+    }
+
+    given renderMyUnionType: Render[MyUnionType] with {
+      override def render(a: MyUnionType): String = a match {
+        case CaseA(n) => n.render
+        case CaseB(name) => name.render
+        case CaseC => "CaseC"
+      }
+    }
+  }
+
+  final case class MyOwnCaseClass(
+    something: MyOwnCaseClass.Something
+  )
+  object MyOwnCaseClass {
+
+    given renderMyOwnCaseClass: Render[MyOwnCaseClass] with {
+      override def render(a: MyOwnCaseClass): String =
+        s"MyOwnCaseClass(something=${a.something.render})"
+    }
+
+    /* This doesn't work with the existing render from the extension method of A using Render[A]
+     */
+//    extension (myOwnCaseClass: MyOwnCaseClass) {
+//      def render: String = s"MyOwnCaseClass(something=${myOwnCaseClass.something.render})"
+//    }
+
+    type Something = Something.Type
+    object Something {
+      opaque type Type = String
+      def apply(something: String): Something = something
+
+      given somethingCanEqual: CanEqual[Something, Something] = CanEqual.derived
+
+      extension (something: Something) {
+        def value: String = something
+      }
+
+      given RenderSomething: Render[Something] with {
+        override def render(a: Something): String = a.value
+      }
+    }
+
+  }
+
+}

--- a/modules/extras-render/shared/src/test/scala/extras/render/syntaxSpec.scala
+++ b/modules/extras-render/shared/src/test/scala/extras/render/syntaxSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 /** @author Kevin Lee
   * @since 2022-10-15
   */
-object syntaxSpec extends Properties {
+object syntaxSpec extends Properties with ScalaVersionSpecificSyntaxSpec {
 
   import extras.render.syntax._
 
@@ -39,7 +39,7 @@ object syntaxSpec extends Properties {
 
     /* String interpolation */
     property("test render interpolation", testRenderInterpolation),
-  )
+  ) ++ scalaVersionSpecificTests
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testUnitRender: Result =


### PR DESCRIPTION
Fix #554: [`extras-render`] `.render` `extension` method doesn't work well when there's a method with the same name exists in the context in Scala 3

- Add `ScalaVersionSpecificSyntaxSpec` for Scala 3: to test `render` functionality with Scala 3 features (`opaque type`s, `union type`s, `given` instances)
  * Opaque types (`Name`, `MyUnionType`, `Something`)
  * Union types (`CaseA` | `CaseB` | `CaseC.type`)
  * Given instances instead of implicit definitions
  * Extension methods for opaque type operations
- Integrate version-specific tests into existing `syntaxSpec`
- Test property-based scenarios for custom types with render functionality