### PR TITLE
extras v0.46.1

### DIFF
--- a/changelogs/0.46.1.md
+++ b/changelogs/0.46.1.md
@@ -1,0 +1,93 @@
+## [0.46.1](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am48) - 2025-07-27
+
+## Bug Fixed
+
+* [`extras-render`] `.render` extension method doesn't work well when there's a method with the same name exists in the context in Scala 3 (#554)
+
+  * Version: `0.46.0`
+  * Scala Version: `3`
+  * Java Version: `n/a`
+
+  The following code
+  ```scala 3
+  import extras.render.Render
+  import extras.render.syntax.*
+
+  final case class JdkByCs(
+    version: JdkByCs.Version,
+  ) derives CanEqual
+  object JdkByCs {
+
+    extension (jdkByCs: JdkByCs) {
+      def render: String =
+        s"JdkByCs(version=${jdkByCs.version.render})" // <= this .render fails!
+    }
+
+    type Version = Version.Type
+    object Version extends Newtype[SemVer | DecVer | DotSeparatedVersion] {
+
+      extension (version: Version) {
+        def major: MajorVersion = version.value match {
+          case SemVer(m, n, _, _, _) =>
+            MajorVersion(if (m.value == 1) n.value else m.value)
+
+          case DecVer(m, n, _, _) =>
+            MajorVersion(if (m.value == 1) n.value else m.value)
+
+          case DotSeparatedVersion(v, vs) =>
+            val vNum = v.toInt
+            MajorVersion(
+              if vNum == 1 then
+                vs.take(1)
+                  .headOption
+                  .filter(_.forall(_.isDigit))
+                  .fold(vNum)(_.toInt)
+              else vNum
+            )
+        }
+
+      }
+
+      given renderVersion: Render[Version] with {
+
+        def render(a: Version): String = a.value match {
+          case v: SemVer => SemVer.render(v)
+          case v: DecVer => DecVer.render(v)
+          case DotSeparatedVersion(v, vs) => s"$v.${vs.mkString(".")}"
+        }
+      }
+    }
+
+  }
+  ```
+  fails in compilation with an error like
+  ```
+  [error] -- [E008] Not Found Error: /home/runner/work/jdk-sym-link/jdk-sym-link/modules/jdk-sym-link-core/src/main/scala/jdksymlink/cs/CoursierCmd.scala:90:103
+  [error] 90 |        s"""JdkByCs(version=${jdkByCs.version.render})
+  [error]    |                              ^^^^^^^^^^^^^^^^^^^^^^
+  [error]    |value render is not a member of jdksymlink.cs.CoursierCmd.JdkByCs.Version.
+  [error]    |An extension method was tried, but could not be fully constructed:
+  [error]    |
+  [error]    |    jdksymlink.cs.CoursierCmd.JdkByCs.render(jdkByCs.version)
+  [error]    |
+  [error]    |    failed with:
+  [error]    |
+  [error]    |        Found:    (jdkByCs.version : jdksymlink.cs.CoursierCmd.JdkByCs.Version)
+  [error]    |        Required: jdksymlink.cs.CoursierCmd.JdkByCs
+  
+  ```
+
+  * Cause:
+  
+    Although it's an extension method with the name `render` for `JdkByCs`, it looks like this extension method
+    ```scala 3
+        extension (jdkByCs: JdkByCs) {
+          def render: String =
+            s"""JdkByCs(version=${jdkByCs.version.render})" // <= this .render fails!
+        }
+    ```
+    has precedence over the extension method of the same name for `JdkByCs.Version`.
+
+  * Solution:
+  
+    Revert the `render` extension method for Scala 3 back to an `implicit value class`.


### PR DESCRIPTION
# extras v0.46.1
## [0.46.1](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am48) - 2025-07-27

## Bug Fixed

* [`extras-render`] `.render` extension method doesn't work well when there's a method with the same name exists in the context in Scala 3 (#554)

  * Version: `0.46.0`
  * Scala Version: `3`
  * Java Version: `n/a`

  The following code
  ```scala 3
  import extras.render.Render
  import extras.render.syntax.*

  final case class JdkByCs(
    version: JdkByCs.Version,
  ) derives CanEqual
  object JdkByCs {

    extension (jdkByCs: JdkByCs) {
      def render: String =
        s"JdkByCs(version=${jdkByCs.version.render})" // <= this .render fails!
    }

    type Version = Version.Type
    object Version extends Newtype[SemVer | DecVer | DotSeparatedVersion] {

      extension (version: Version) {
        def major: MajorVersion = version.value match {
          case SemVer(m, n, _, _, _) =>
            MajorVersion(if (m.value == 1) n.value else m.value)

          case DecVer(m, n, _, _) =>
            MajorVersion(if (m.value == 1) n.value else m.value)

          case DotSeparatedVersion(v, vs) =>
            val vNum = v.toInt
            MajorVersion(
              if vNum == 1 then
                vs.take(1)
                  .headOption
                  .filter(_.forall(_.isDigit))
                  .fold(vNum)(_.toInt)
              else vNum
            )
        }

      }

      given renderVersion: Render[Version] with {

        def render(a: Version): String = a.value match {
          case v: SemVer => SemVer.render(v)
          case v: DecVer => DecVer.render(v)
          case DotSeparatedVersion(v, vs) => s"$v.${vs.mkString(".")}"
        }
      }
    }

  }
  ```
  fails in compilation with an error like
  ```
  [error] -- [E008] Not Found Error: /home/runner/work/jdk-sym-link/jdk-sym-link/modules/jdk-sym-link-core/src/main/scala/jdksymlink/cs/CoursierCmd.scala:90:103
  [error] 90 |        s"""JdkByCs(version=${jdkByCs.version.render})
  [error]    |                              ^^^^^^^^^^^^^^^^^^^^^^
  [error]    |value render is not a member of jdksymlink.cs.CoursierCmd.JdkByCs.Version.
  [error]    |An extension method was tried, but could not be fully constructed:
  [error]    |
  [error]    |    jdksymlink.cs.CoursierCmd.JdkByCs.render(jdkByCs.version)
  [error]    |
  [error]    |    failed with:
  [error]    |
  [error]    |        Found:    (jdkByCs.version : jdksymlink.cs.CoursierCmd.JdkByCs.Version)
  [error]    |        Required: jdksymlink.cs.CoursierCmd.JdkByCs
  
  ```

  * Cause:
  
    Although it's an extension method with the name `render` for `JdkByCs`, it looks like this extension method
    ```scala 3
        extension (jdkByCs: JdkByCs) {
          def render: String =
            s"""JdkByCs(version=${jdkByCs.version.render})" // <= this .render fails!
        }
    ```
    has precedence over the extension method of the same name for `JdkByCs.Version`.

  * Solution:
  
    Revert the `render` extension method for Scala 3 back to an `implicit value class`.
