### PR TITLE
Close #562: [`extras-testing-tools`] Add compile-time error check for Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -466,6 +466,10 @@ lazy val extrasHedgehogCatsEffect3Js  = extrasHedgehogCe3.js.settings(Test / for
 lazy val extrasTestingTools = crossSubProject("testing-tools", crossProject(JVMPlatform, JSPlatform))
   .settings(
     crossScalaVersions := props.CrossScalaVersions,
+    libraryDependencies ++= (if (isScala3(scalaVersion.value))
+                               List.empty
+                             else
+                               List(libs.scalaReflect(scalaVersion.value))),
     libraryDependencies :=
       removeScala3Incompatible(scalaVersion.value, libraryDependencies.value),
     Test / console / scalacOptions := List.empty,

--- a/modules/extras-testing-tools/shared/src/main/scala-2/extras/testing/CompileTimeError.scala
+++ b/modules/extras-testing-tools/shared/src/main/scala-2/extras/testing/CompileTimeError.scala
@@ -1,0 +1,8 @@
+package extras.testing
+
+/** @author Kevin Lee
+  * @since 2025-07-28
+  */
+object CompileTimeError {
+  def from(code: String): String = macro MacroCompileTimeError.fromImpl
+}

--- a/modules/extras-testing-tools/shared/src/main/scala-2/extras/testing/MacroCompileTimeError.scala
+++ b/modules/extras-testing-tools/shared/src/main/scala-2/extras/testing/MacroCompileTimeError.scala
@@ -1,0 +1,51 @@
+package extras.testing
+
+import scala.annotation.nowarn
+import scala.reflect.macros.ParseException
+import scala.reflect.macros.TypecheckException
+import scala.reflect.macros.blackbox.Context
+
+/** This is from munit's MacroCompatScala2.compileErrorsImpl
+  *   https://github.com/scalameta/munit/blob/effba46e485b718b03ce215835450c7e51a381f0/munit/shared/src/main/scala/munit/internal/MacroCompatScala2.scala#L60-L86
+  * @author Kevin Lee
+  * @since 2025-07-28
+  */
+object MacroCompileTimeError {
+
+  def fromImpl(c: Context)(code: c.Tree): c.Tree = {
+    import c.universe._
+    val toParse: String = code match {
+      case Literal(Constant(literal: String)) => literal
+      case _ =>
+        c.abort(
+          code.pos,
+          "cannot compile dynamic expressions, only constant literals.\n" +
+            "To fix this problem, pass in a string literal in double quotes \"...\"",
+        )
+    }
+
+    @nowarn("msg=deprecated")
+    def formatError(message: String, pos: scala.reflect.api.Position): String =
+      new StringBuilder()
+        .append("error:")
+        .append(if (message.contains('\n')) "\n" else " ")
+        .append(message)
+        .append("\n")
+        .append(pos.lineContent)
+        .append("\n")
+        .append(" " * (pos.column - 1))
+        .append("^")
+        .toString()
+
+    val message: String =
+      try {
+        val _ = c.typecheck(c.parse(s"{\n$toParse\n}"))
+        ""
+      } catch {
+        case e: ParseException => formatError(e.getMessage(), e.pos)
+        case e: TypecheckException => formatError(e.getMessage(), e.pos)
+      }
+    Literal(Constant(message))
+  }
+
+}

--- a/modules/extras-testing-tools/shared/src/test/scala-2/extras/testing/CompileTimeErrorSpec.scala
+++ b/modules/extras-testing-tools/shared/src/test/scala-2/extras/testing/CompileTimeErrorSpec.scala
@@ -1,0 +1,37 @@
+package extras.testing
+
+import hedgehog._
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2025-08-06
+  */
+object CompileTimeErrorSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    example("test CompileTimeError.from - no error case", testCompileTimeErrorNoErrorCase),
+    example("test CompileTimeError.from - error case", testCompileTimeErrorErrorCase),
+  )
+
+  def testCompileTimeErrorNoErrorCase: Result = {
+    val actual = CompileTimeError.from(
+      """
+      val n = 2
+      println("n * 2")
+      """
+    )
+
+    actual ==== ""
+  }
+
+  def testCompileTimeErrorErrorCase: Result = {
+    val actual = CompileTimeError.from("n * 2")
+
+    val expected =
+      """error: not found: value n
+        |n * 2
+        |^""".stripMargin
+    actual ==== expected
+  }
+
+}


### PR DESCRIPTION
Close #562: [`extras-testing-tools`] Add compile-time error check for Scala 2

- Add `CompileTimeError.from()` `macro` for capturing compilation errors.
- It's based on munit's macro implementation.
- Scala 3 has its own compile-time API to do it so it's not required for Scala 3.