### PR TITLE
extras v0.47.0

### DIFF
--- a/changelogs/0.47.0.md
+++ b/changelogs/0.47.0.md
@@ -1,0 +1,14 @@
+## [0.47.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am49) - 2025-08-06
+
+## New Features
+
+* [`extras-testing-tools`] Add `Scala.js` support (#560)
+***
+* [`extras-testing-tools`] Add compile-time error check for Scala 2 (#562)
+
+  ```scala
+  CompileTimeError.from(
+    "some Scala code causing a compile-time error"
+  )
+  // String = "compile-time error message"
+  ```


### PR DESCRIPTION
# extras v0.47.0
## [0.47.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am49) - 2025-08-06

## New Features

* [`extras-testing-tools`] Add `Scala.js` support (#560)
***
* [`extras-testing-tools`] Add compile-time error check for Scala 2 (#562)

  ```scala
  CompileTimeError.from(
    "some Scala code causing a compile-time error"
  )
  // String = "compile-time error message"
  ```
