### PR TITLE
extras v0.48.0

### DIFF
--- a/changelogs/0.48.0.md
+++ b/changelogs/0.48.0.md
@@ -1,0 +1,5 @@
+## [0.48.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am50) - 2025-08-15
+
+## New Features
+
+* Support Scala Native (#567)


### PR DESCRIPTION
# extras v0.48.0
## [0.48.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am50) - 2025-08-15

## New Features

* Support Scala Native (#567)
