### PR TITLE
extras v0.49.0

### DIFF
--- a/changelogs/0.49.0.md
+++ b/changelogs/0.49.0.md
@@ -1,0 +1,6 @@
+## [0.49.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am51) - 2025-08-19
+
+## New Features
+
+* [extras-testing-tools] Support Scala Native (#572)
+  * `StubTools` is not included because `Thread.currentThread.getStackTrace.toList` returns an empty `List`.


### PR DESCRIPTION
# extras v0.49.0
## [0.49.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am51) - 2025-08-19

## New Features

* [extras-testing-tools] Support Scala Native (#572)
  * `StubTools` is not included because `Thread.currentThread.getStackTrace.toList` returns an empty `List`.
