### PR TITLE
Bump sbt and sbt plugins

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.6
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,15 +3,15 @@ import sbt.Defaults.sbtPluginExtra
 logLevel := sbt.Level.Warn
 scalaVersion := "2.12.18"
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.3.2")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.3")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.11.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
-addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.2")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.17.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.6")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.3")
+addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.8.1")
+addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.18.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
@@ -19,7 +19,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.8")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-val sbtDevOopsVersion     = "3.2.1"
+val sbtDevOopsVersion     = "3.3.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
## Bump sbt and sbt plugins

- Update sbt to 1.11.7
- Update plugins:
  - sbt-ci-release: 1.11.1 => 1.11.2
  - sbt-wartremover: 3.3.2 => 3.4.3
  - sbt-scalafix: 0.11.0 => 0.14.5
  - sbt-scalafmt: 2.5.0 => 2.5.6
  - sbt-scoverage: 2.3.1 => 2.4.3
  - sbt-mdoc: 2.5.2 => 2.8.1
  - sbt-docusaur: 0.17.0 => 0.18.0
  - sbt-devoops: 3.2.1 => 3.3.1