### PR TITLE
extras v0.50.0

### DIFF
--- a/changelogs/0.50.0.md
+++ b/changelogs/0.50.0.md
@@ -1,0 +1,64 @@
+## [0.50.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am52) - 2025-12-25 🎄🎁
+
+## New Features
+
+* [`extras-core`] Add the Elvis operator (`?:`) to `extras.core.syntax` for Scala 3 (#580)
+
+  ![Image](https://github.com/user-attachments/assets/dace5e5a-a542-465f-bbb2-9423c66dfa60)
+
+  ```scala 3
+  val a: String | Null = "blah"
+  
+  a ?: "Unknown"
+  // String = "blah"
+  ```
+  ```scala 3
+  val a: String | Null = null
+  
+  a ?: "Unknown"
+  // String = "Unknown"
+  ```
+  ```scala 3
+  val a: String | Null = "blah"
+  
+  a ?: { println("Hello!"); "Unknown" }
+  // String = "blah"
+  ```
+  ```scala 3
+  val a: String | Null = null
+  
+  a ?: { println("Hello!"); "Unknown" }
+  // Hello!
+  // String = "Unknown"
+  ```
+***
+
+* [`extras-core`] Add the Elvis operator (`?:=`) to `extras.core.syntax` for Scala 2 (#594)
+  * In Scala 2, operator (method) names ending with `:` are right-associative, so `a ?: b` would be evaluated as `b.?:(a)`.
+
+    Since we need the possibly-null value (`a`) to be the receiver, the operator is provided as `?:=` (not ending with `:`), so `a ?:= b` is evaluated as `a.?:=(b)`.
+  * Scala 2 doesn't have union types like `A | Null`, so this operates on a plain `A` value that may be `null` at runtime.
+
+  * Also, for compatibility with Scala 2 code, Scala 3 `predefs` should have `?:=` as an alias for `?:`.
+
+## Changes
+
+* Rename `extras.core.syntax.string` to `extras.core.syntax.strings` (#578)
+
+  Also, replace the `package object` for `extras.core.syntax` with a package named `extras.core.syntax`.
+
+## Internal Housekeeping
+
+* Upgrade `doobie` for cats-effect 3 to `1.0.0-RC10` (#587)
+***
+* Update libraries (#591)
+
+  - Update `cats` to `2.13.0`
+  - Update `cats-effect` 3 to `3.6.3`
+  - Update `kittens` to `3.5.0`
+  - Update `circe` to `0.14.13`
+  - Update `fs2` v3 to `3.12.2`
+  - Update `hedgehog-extra` to `0.19.0`
+  - Update `embedded-postgres` to `2.2.0`
+  - Update `effectie` to `2.3.0`
+


### PR DESCRIPTION
# extras v0.50.0

## [0.50.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am52) - 2025-12-25 🎄🎁

## New Features

* [`extras-core`] Add the Elvis operator (`?:`) to `extras.core.syntax` for Scala 3 (#580)

  ![Image](https://github.com/user-attachments/assets/dace5e5a-a542-465f-bbb2-9423c66dfa60)

  ```scala 3
  val a: String | Null = "blah"
  
  a ?: "Unknown"
  // String = "blah"
  ```
  ```scala 3
  val a: String | Null = null
  
  a ?: "Unknown"
  // String = "Unknown"
  ```
  ```scala 3
  val a: String | Null = "blah"
  
  a ?: { println("Hello!"); "Unknown" }
  // String = "blah"
  ```
  ```scala 3
  val a: String | Null = null
  
  a ?: { println("Hello!"); "Unknown" }
  // Hello!
  // String = "Unknown"
  ```
***

* [`extras-core`] Add the Elvis operator (`?:=`) to `extras.core.syntax` for Scala 2 (#594)
  * In Scala 2, operator (method) names ending with `:` are right-associative, so `a ?: b` would be evaluated as `b.?:(a)`.

    Since we need the possibly-null value (`a`) to be the receiver, the operator is provided as `?:=` (not ending with `:`), so `a ?:= b` is evaluated as `a.?:=(b)`.
  * Scala 2 doesn't have union types like `A | Null`, so this operates on a plain `A` value that may be `null` at runtime.

  * Also, for compatibility with Scala 2 code, Scala 3 `predefs` should have `?:=` as an alias for `?:`.

## Changes

* Rename `extras.core.syntax.string` to `extras.core.syntax.strings` (#578)

  Also, replace the `package object` for `extras.core.syntax` with a package named `extras.core.syntax`.

## Internal Housekeeping

* Upgrade `doobie` for cats-effect 3 to `1.0.0-RC10` (#587)
***
* Update libraries (#591)

  - Update `cats` to `2.13.0`
  - Update `cats-effect` 3 to `3.6.3`
  - Update `kittens` to `3.5.0`
  - Update `circe` to `0.14.13`
  - Update `fs2` v3 to `3.12.2`
  - Update `hedgehog-extra` to `0.19.0`
  - Update `embedded-postgres` to `2.2.0`
  - Update `effectie` to `2.3.0`

