### PR TITLE
Update README and API docs: Rename Elvis Operator in Scala 2 to Crying Elvis Operator

### DIFF
--- a/changelogs/0.50.0.md
+++ b/changelogs/0.50.0.md
@@ -33,13 +33,42 @@
   ```
 ***
 
-* [`extras-core`] Add the Elvis operator (`?:=`) to `extras.core.syntax` for Scala 2 (#594)
-  * In Scala 2, operator (method) names ending with `:` are right-associative, so `a ?: b` would be evaluated as `b.?:(a)`.
+* [`extras-core`] Add the Crying Elvis Operator (`?:=`) to `extras.core.syntax` for Scala 2 (#594)
+
+  <img width="640" height="640" alt="crying-elvis-operator-resized" src="https://github.com/user-attachments/assets/a367ff60-5d2d-4064-b692-1797bb851a7b" />
+
+  * Unlike Scala 3's extension methods, in Scala 2, extension methods are just regular methods in an implicit value class. As a result, method names ending with `:` are right-associative, so `a ?: b` is evaluated as `b.?:(a)`.
 
     Since we need the possibly-null value (`a`) to be the receiver, the operator is provided as `?:=` (not ending with `:`), so `a ?:= b` is evaluated as `a.?:=(b)`.
   * Scala 2 doesn't have union types like `A | Null`, so this operates on a plain `A` value that may be `null` at runtime.
 
   * Also, for compatibility with Scala 2 code, Scala 3 `predefs` should have `?:=` as an alias for `?:`.
+
+  ```scala
+  val a = "blah"
+  
+  a ?:= "Unknown"
+  // String = "blah"
+  ```
+  ```scala
+  val a: String = null
+  
+  a ?:= "Unknown"
+  // String = "Unknown"
+  ```
+  ```scala
+  val a = "blah"
+  
+  a ?:= { println("Hello!"); "Unknown" }
+  // String = "blah"
+  ```
+  ```scala
+  val a: String = null
+  
+  a ?:= { println("Hello!"); "Unknown" }
+  // Hello!
+  // String = "Unknown"
+  ```
 
 ## Changes
 

--- a/modules/extras-core/shared/src/main/scala-2/extras/core/syntax/predefs.scala
+++ b/modules/extras-core/shared/src/main/scala-2/extras/core/syntax/predefs.scala
@@ -12,7 +12,9 @@ object predefs extends predefs {
     *
     * Scala 2 doesn't have union types like `A | Null`, so this operates on a plain `A` value that may be `null` at runtime.
     *
-    * In Scala 2, operator (method) names ending with `:` are right-associative, so `a ?: b` would be evaluated as `b.?: (a)`.
+    * Unlike Scala 3's extension methods, in Scala 2, extension methods are just regular methods in an implicit value class.
+    * As a result, method names ending with `:` are right-associative, so `a ?: b` is evaluated as `b.?:(a)`.
+    *
     * Since we need the possibly-null value (`a`) to be the receiver, the operator is provided as `?:=` (not ending with `:`),
     * so `a ?:= b` is evaluated as `a.?:=(b)`.
     *


### PR DESCRIPTION
## Update README and API docs: Rename Elvis Operator in Scala 2 to Crying Elvis Operator

- Rename `?:=` to Crying Elvis Operator in `changelogs/0.50.0.md`.
- Add image and code examples to the changelog.
- Clarify why `?:=` is used in Scala 2 (right-associativity of methods ending in `:`) in both the changelog and `predefs.scala`.