### PR TITLE
Update image alt text and link in changelog `0.50.0`

### DIFF
--- a/changelogs/0.50.0.md
+++ b/changelogs/0.50.0.md
@@ -4,7 +4,7 @@
 
 * [`extras-core`] Add the Elvis operator (`?:`) to `extras.core.syntax` for Scala 3 (#580)
 
-  ![Image](https://github.com/user-attachments/assets/dace5e5a-a542-465f-bbb2-9423c66dfa60)
+  ![Elvis Operator](https://github.com/user-attachments/assets/dace5e5a-a542-465f-bbb2-9423c66dfa60)
 
   ```scala 3
   val a: String | Null = "blah"
@@ -35,7 +35,7 @@
 
 * [`extras-core`] Add the Crying Elvis Operator (`?:=`) to `extras.core.syntax` for Scala 2 (#594)
 
-  <img width="640" height="640" alt="crying-elvis-operator-resized" src="https://github.com/user-attachments/assets/a367ff60-5d2d-4064-b692-1797bb851a7b" />
+  ![Crying Elvis Operator](https://github.com/user-attachments/assets/fbf021d0-c6b0-40dd-b756-22b7f3d4f9a2)
 
   * Unlike Scala 3's extension methods, in Scala 2, extension methods are just regular methods in an implicit value class. As a result, method names ending with `:` are right-associative, so `a ?: b` is evaluated as `b.?:(a)`.
 


### PR DESCRIPTION
Update image alt text and link in changelog `0.50.0`

- Update alt text for Elvis operator image
- Update Crying Elvis operator image link and convert to markdown format
