### PR TITLE
Close #599: [`extras-core`] `extras.core.syntax.all` is missing `predefs` in Scala 2

### DIFF
--- a/modules/extras-core/shared/src/main/scala-2/extras/core/syntax/all.scala
+++ b/modules/extras-core/shared/src/main/scala-2/extras/core/syntax/all.scala
@@ -3,5 +3,5 @@ package extras.core.syntax
 /** @author Kevin Lee
   * @since 2022-06-25
   */
-trait all extends strings
+trait all extends strings with predefs
 object all extends all

--- a/modules/extras-core/shared/src/test/scala-2/extras/core/syntax/predefsSpec.scala
+++ b/modules/extras-core/shared/src/test/scala-2/extras/core/syntax/predefsSpec.scala
@@ -3,12 +3,20 @@ package extras.core.syntax
 import hedgehog._
 import hedgehog.runner._
 
-import extras.core.syntax.predefs._
-
 /** @author Kevin Lee
   * @since 2025-09-06
   */
-object predefsSpec extends Properties {
+object predefsSpec extends Properties with CommonPredefsSpec {
+  override val predefsImport: predefs = extras.core.syntax.predefs
+}
+
+trait CommonPredefsSpec {
+  self: Properties =>
+
+  val predefsImport: extras.core.syntax.predefs
+
+  import predefsImport._
+
   def tests: List[Test] = List(
     property("a ?:= alternative where a is non-null value should return a", testElvisWithNonNull),
     property(

--- a/modules/extras-core/shared/src/test/scala-3/extras/core/syntax/predefsSpec.scala
+++ b/modules/extras-core/shared/src/test/scala-3/extras/core/syntax/predefsSpec.scala
@@ -3,14 +3,21 @@ package extras.core.syntax
 import hedgehog.*
 import hedgehog.runner.*
 
-import extras.core.syntax.predefs.*
-
 import scala.language.unsafeNulls
 
 /** @author Kevin Lee
   * @since 2025-09-06
   */
-object predefsSpec extends Properties {
+object predefsSpec extends Properties, CommonPredefsSpec {
+  override val predefsImport: predefs = extras.core.syntax.predefs
+}
+trait CommonPredefsSpec {
+  self: Properties =>
+
+  val predefsImport: predefs
+
+  import predefsImport.*
+
   def tests: List[Test] = List(
     // ?:
     property("a ?: alternative where a is non-null value should return a", testElvisWithNonNull),

--- a/modules/extras-core/shared/src/test/scala/extras/core/syntax/allSpec.scala
+++ b/modules/extras-core/shared/src/test/scala/extras/core/syntax/allSpec.scala
@@ -1,0 +1,15 @@
+package extras.core.syntax
+
+import hedgehog.runner._
+
+/** @author Kevin Lee
+  * @since 2025-12-27
+  */
+object allSpec extends Properties with CommonStringsSpec with CommonPredefsSpec {
+
+  override val stringsImport: strings = extras.core.syntax.all
+
+  override val predefsImport: predefs = extras.core.syntax.all
+
+  override def tests: List[Test] = super[CommonStringsSpec].tests ++ super[CommonPredefsSpec].tests
+}

--- a/modules/extras-core/shared/src/test/scala/extras/core/syntax/stringsSpec.scala
+++ b/modules/extras-core/shared/src/test/scala/extras/core/syntax/stringsSpec.scala
@@ -6,7 +6,17 @@ import hedgehog.runner._
 /** @author Kevin Lee
   * @since 2022-06-25
   */
-object stringsSpec extends Properties {
+object stringsSpec extends Properties with CommonStringsSpec {
+  override val stringsImport: strings = extras.core.syntax.strings
+}
+
+trait CommonStringsSpec {
+  self: Properties =>
+
+  val stringsImport: strings
+
+  import stringsImport._
+
   override def tests: List[Test] = List(
     property("test String.encodeToUnicode", testEncodeToUnicode)
   )
@@ -14,7 +24,7 @@ object stringsSpec extends Properties {
   def testEncodeToUnicode: Property = for {
     s <- Gen.string(Gen.unicode, Range.linear(1, 100)).log("s")
   } yield {
-    import strings._
+
     val expected = s
       .map(_.toInt)
       .map { c =>


### PR DESCRIPTION
Close #599: [`extras-core`] `extras.core.syntax.all` is missing `predefs` in Scala 2