### PR TITLE
extras v0.50.1

### DIFF
--- a/changelogs/0.50.1.md
+++ b/changelogs/0.50.1.md
@@ -1,0 +1,5 @@
+## [0.50.1](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am53) - 2025-12-27
+
+## Bug Fixes
+
+* [`extras-core`] `extras.core.syntax.all` is missing `predefs` in Scala 2 (#599)


### PR DESCRIPTION
# extras v0.50.1

## [0.50.1](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am53) - 2025-12-27

## Bug Fixes

* [`extras-core`] `extras.core.syntax.all` is missing `predefs` in Scala 2 (#599)
