### PR TITLE
Close #607: [`extras-scala-io`] Add dimming in ANSI Color

### DIFF
--- a/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/Color.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/Color.scala
@@ -27,6 +27,7 @@ object Color {
   case object Blink extends Color
   case object Reversed extends Color
   case object Invisible extends Color
+  case object Dim extends Color
 
   def black: Color = Black
 
@@ -71,6 +72,8 @@ object Color {
   def reversed: Color = Reversed
 
   def invisible: Color = Invisible
+
+  def dim: Color = Dim
 
   def render(color: Color): String = color match {
     case Black =>
@@ -138,6 +141,9 @@ object Color {
 
     case Invisible =>
       AnsiColor.INVISIBLE
+
+    case Dim =>
+      "\u001b[2m"
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))

--- a/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/syntax/ColorSyntax.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-2/extras/scala/io/syntax/ColorSyntax.scala
@@ -39,6 +39,7 @@ object ColorSyntax {
     def blink: String         = colored(Color.blink)
     def reversedColor: String = colored(Color.reversed)
     def invisible: String     = colored(Color.invisible)
+    def dim: String           = colored(Color.dim)
   }
 
 }

--- a/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/Color.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/Color.scala
@@ -25,6 +25,7 @@ enum Color derives CanEqual {
   case Blink
   case Reversed
   case Invisible
+  case Dim
 }
 
 object Color {
@@ -72,6 +73,8 @@ object Color {
   def reversed: Color = Color.Reversed
 
   def invisible: Color = Color.Invisible
+
+  def dim: Color = Color.Dim
 
   extension (colour: Color) {
     def render: String = colour match {
@@ -140,6 +143,9 @@ object Color {
 
       case Invisible =>
         AnsiColor.INVISIBLE
+
+      case Dim =>
+        "\u001b[2m"
     }
 
     def toAnsi: String = Color.render(colour)

--- a/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/syntax/ColorSyntax.scala
+++ b/modules/extras-scala-io/shared/src/main/scala-3/extras/scala/io/syntax/ColorSyntax.scala
@@ -34,6 +34,7 @@ trait ColorSyntax {
     def blink: String         = colored(Color.blink)
     def reversedColor: String = colored(Color.reversed)
     def invisible: String     = colored(Color.invisible)
+    def dim: String           = colored(Color.dim)
   }
 
 }

--- a/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/ColorTestUtils.scala
+++ b/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/ColorTestUtils.scala
@@ -43,6 +43,7 @@ object ColorTestUtils {
     Color.blink      -> AnsiColor.BLINK,
     Color.reversed   -> AnsiColor.REVERSED,
     Color.invisible  -> AnsiColor.INVISIBLE,
+    Color.dim        -> "\u001b[2m",
   )
 
 }

--- a/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/ColorSyntaxSpec.scala
+++ b/modules/extras-scala-io/shared/src/test/scala/extras/scala/io/syntax/ColorSyntaxSpec.scala
@@ -35,6 +35,7 @@ object ColorSyntaxSpec extends Properties {
     property("test txt.blink", testBlink),
     property("test txt.reversed", testReversed),
     property("test txt.invisible", testInvisible),
+    property("test txt.dim", testDim),
   )
 
   import extras.scala.io.syntax.color._
@@ -236,6 +237,14 @@ object ColorSyntaxSpec extends Properties {
   } yield {
     val actual   = text.invisible
     val expected = colorAndReset(text, AnsiColor.INVISIBLE)
+    actual ==== expected
+  }
+
+  def testDim: Property = for {
+    text <- Gen.string(Gen.alphaNum, Range.linear(3, 5)).log("text")
+  } yield {
+    val actual   = text.dim
+    val expected = colorAndReset(text, "\u001b[2m")
     actual ==== expected
   }
 


### PR DESCRIPTION
Close #607: [`extras-scala-io`] Add dimming in ANSI Color

<img width="1037" height="999" alt="Screenshot 2026-03-14 at 3 15 57 pm" src="https://github.com/user-attachments/assets/63421063-2a89-4a83-9bf9-7ec3cae84992" />
<img width="1116" height="1005" alt="Screenshot 2026-03-14 at 3 16 20 pm" src="https://github.com/user-attachments/assets/d48697fc-fcfb-4b4b-a7b1-34f881ad5e2b" />
<img width="1112" height="1009" alt="Screenshot 2026-03-14 at 3 16 45 pm" src="https://github.com/user-attachments/assets/9d46c452-2608-480c-82c7-6b1cd121dac1" />
<img width="1479" height="1002" alt="Screenshot 2026-03-14 at 3 20 16 pm" src="https://github.com/user-attachments/assets/1faec0ef-20dc-4307-8c5d-965394c10bf5" />
