### PR TITLE
extras v0.51.0

### DIFF
--- a/changelogs/0.51.0.md
+++ b/changelogs/0.51.0.md
@@ -1,0 +1,58 @@
+## [0.51.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am54) - 2026-03-14
+
+## New Features
+
+* [`extras-scala-io`] Add dimming in ANSI Color (#607)
+
+  e.g.)
+  ```scala
+  import extras.scala.io.syntax.color._
+
+  "Hello".dim
+  "Hello".blue.dim
+  "Hello".rgbed(0x00eeff).dim
+  ```
+
+  <img width="1037" height="999" alt="Screenshot 2026-03-14 at 3 15 57 pm" src="https://github.com/user-attachments/assets/63421063-2a89-4a83-9bf9-7ec3cae84992" />
+  <img width="1116" height="1005" alt="Screenshot 2026-03-14 at 3 16 20 pm" src="https://github.com/user-attachments/assets/d48697fc-fcfb-4b4b-a7b1-34f881ad5e2b" />
+  <img width="1112" height="1009" alt="Screenshot 2026-03-14 at 3 16 45 pm" src="https://github.com/user-attachments/assets/9d46c452-2608-480c-82c7-6b1cd121dac1" />
+  <img width="1479" height="1002" alt="Screenshot 2026-03-14 at 3 20 16 pm" src="https://github.com/user-attachments/assets/1faec0ef-20dc-4307-8c5d-965394c10bf5" />
+
+
+## Bug Fixes
+
+* [`extras-scala-io`] Applying multiple colors adds multiple resets at the end (#609)
+
+  * Before
+
+    ```scala
+    import extras.scala.io.syntax.color._
+    
+    "Hello".blue.bold.dim
+    // \u001b[2m\u001b[1m\u001b[34mHello\u001b[0m\u001b[0m\u001b[0m
+    //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "\u001b[0m" x 3
+    ```
+    
+    ```scala
+    import extras.scala.io.syntax.truecolor.all._
+    
+    "Hello".rgbed(0x223344).rgbed(0xaa00ee).rgbed(0x00bb33)
+    // \u001b[38;2;0;187;51m\u001b[38;2;170;0;238m\u001b[38;2;34;51;68mHello\u001b[0m\u001b[0m\u001b[0m
+    //                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "\u001b[0m" x 3
+    ```
+  * Now
+    ```scala
+    import extras.scala.io.syntax.color._
+    
+    "Hello".blue.bold.dim
+    // \u001b[2m\u001b[1m\u001b[34mHello\u001b[0m
+    //                                  ^^^^^^^^^
+    ```
+    
+    ```scala
+    import extras.scala.io.syntax.truecolor.all._
+    
+    "Hello".rgbed(0x223344).rgbed(0xaa00ee).rgbed(0x00bb33)
+    // \u001b[38;2;0;187;51m\u001b[38;2;170;0;238m\u001b[38;2;34;51;68mHello\u001b[0m
+    //                                                                      ^^^^^^^^^
+    ```


### PR DESCRIPTION
# extras v0.51.0
## [0.51.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am54) - 2026-03-14

## New Features

* [`extras-scala-io`] Add dimming in ANSI Color (#607)

  e.g.)
  ```scala
  import extras.scala.io.syntax.color._

  "Hello".dim
  "Hello".blue.dim
  "Hello".rgbed(0x00eeff).dim
  ```

  <img width="1037" height="999" alt="Screenshot 2026-03-14 at 3 15 57 pm" src="https://github.com/user-attachments/assets/63421063-2a89-4a83-9bf9-7ec3cae84992" />
  <img width="1116" height="1005" alt="Screenshot 2026-03-14 at 3 16 20 pm" src="https://github.com/user-attachments/assets/d48697fc-fcfb-4b4b-a7b1-34f881ad5e2b" />
  <img width="1112" height="1009" alt="Screenshot 2026-03-14 at 3 16 45 pm" src="https://github.com/user-attachments/assets/9d46c452-2608-480c-82c7-6b1cd121dac1" />
  <img width="1479" height="1002" alt="Screenshot 2026-03-14 at 3 20 16 pm" src="https://github.com/user-attachments/assets/1faec0ef-20dc-4307-8c5d-965394c10bf5" />


## Bug Fixes

* [`extras-scala-io`] Applying multiple colors adds multiple resets at the end (#609)

  * Before

    ```scala
    import extras.scala.io.syntax.color._
    
    "Hello".blue.bold.dim
    // \u001b[2m\u001b[1m\u001b[34mHello\u001b[0m\u001b[0m\u001b[0m
    //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "\u001b[0m" x 3
    ```
    
    ```scala
    import extras.scala.io.syntax.truecolor.all._
    
    "Hello".rgbed(0x223344).rgbed(0xaa00ee).rgbed(0x00bb33)
    // \u001b[38;2;0;187;51m\u001b[38;2;170;0;238m\u001b[38;2;34;51;68mHello\u001b[0m\u001b[0m\u001b[0m
    //                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "\u001b[0m" x 3
    ```
  * Now
    ```scala
    import extras.scala.io.syntax.color._
    
    "Hello".blue.bold.dim
    // \u001b[2m\u001b[1m\u001b[34mHello\u001b[0m
    //                                  ^^^^^^^^^
    ```
    
    ```scala
    import extras.scala.io.syntax.truecolor.all._
    
    "Hello".rgbed(0x223344).rgbed(0xaa00ee).rgbed(0x00bb33)
    // \u001b[38;2;0;187;51m\u001b[38;2;170;0;238m\u001b[38;2;34;51;68mHello\u001b[0m
    //                                                                      ^^^^^^^^^
    ```
