### PR TITLE
extras v0.52.0

### DIFF
--- a/changelogs/0.52.0.md
+++ b/changelogs/0.52.0.md
@@ -1,0 +1,7 @@
+## [0.52.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am55) - 2026-06-21
+
+## Internal Housekeeping
+
+* Update `doobie` `1.0` to `1.0.0-RC11` (#617)
+* Update Scala.js to `1.20.2` (#619)
+* Update Scala Native to `0.5.10` and `cats-effect` `3` to `3.7.0` (#621)


### PR DESCRIPTION
# extras v0.52.0
## [0.52.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am55) - 2026-06-21

## Internal Housekeeping

* Update `doobie` `1.0` to `1.0.0-RC11` (#617)
* Update Scala.js to `1.20.2` (#619)
* Update Scala Native to `0.5.10` and `cats-effect` `3` to `3.7.0` (#621)
