### PR TITLE
Fix #626: [`extras-render`] Inaccessible `given` instance in Scala `3.8.x` may cause a compilation error

### DIFF
--- a/modules/extras-render/shared/src/main/scala-3/extras/render/Render.scala
+++ b/modules/extras-render/shared/src/main/scala-3/extras/render/Render.scala
@@ -67,8 +67,8 @@ object Render {
       "If you want to have an instance of cats.Contravariant[Render] provided by extras, " +
       """please add `"org.typelevel" %% "cats-core" % CATS_VERSION` to your libraryDependencies in build.sbt"""
   )
-  sealed private[Render] trait CatsContravariant[M[_[_]]]
-  private[Render] object CatsContravariant {
+  sealed trait CatsContravariant[M[_[_]]]
+  object CatsContravariant {
     @SuppressWarnings(Array("org.wartremover.warts.Null"))
     inline given getCatsContravariant: CatsContravariant[cats.Contravariant] = null // scalafix:ok DisableSyntax.null
   }


### PR DESCRIPTION
Fix #626: [`extras-render`] Inaccessible `given` instance in Scala `3.8.x` may cause a compilation error