### PR TITLE
extras v0.53.0

### DIFF
--- a/changelogs/0.53.0.md
+++ b/changelogs/0.53.0.md
@@ -1,0 +1,6 @@
+## [0.53.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am56) - 2026-06-23
+
+## Bug Fixed
+
+* Fix: [`extras-render`] Inaccessible `given` instance in Scala `3.8.x` may cause a compilation error (#626)
+  * Bug details: kevin-lee/orphan/issues/96


### PR DESCRIPTION
# extras v0.53.0
## [0.53.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am56) - 2026-06-23

## Bug Fixed

* Fix: [`extras-render`] Inaccessible `given` instance in Scala `3.8.x` may cause a compilation error (#626)
  * Bug details: kevin-lee/orphan/issues/96
