### PR TITLE
extras v0.54.0

### DIFF
--- a/changelogs/0.54.0.md
+++ b/changelogs/0.54.0.md
@@ -1,0 +1,11 @@
+## [0.54.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am57) - 2026-06-27
+
+## Internal Housekeeping
+
+* Update `doobie` `1` from `1.0.0-RC11` to `1.0.0-RC12` (#625)
+* Update libraries (#630)
+  * `fs2` `3`: `3.12.2` => `3.13.0`
+  * `http4s` `0.23`: `0.23.16` => `0.23.33`
+  * `hedgehog`: `0.13.0` => `0.13.1`
+  * `hedgehog-extra`: `0.19.0` => `0.21.0`
+  * `effectie`: `2.3.0` => `2.4.0`


### PR DESCRIPTION
# extras v0.54.0
## [0.54.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am57) - 2026-06-27

## Internal Housekeeping

* Update `doobie` `1` from `1.0.0-RC11` to `1.0.0-RC12` (#625)
* Update libraries (#630)
  * `fs2` `3`: `3.12.2` => `3.13.0`
  * `http4s` `0.23`: `0.23.16` => `0.23.33`
  * `hedgehog`: `0.13.0` => `0.13.1`
  * `hedgehog-extra`: `0.19.0` => `0.21.0`
  * `effectie`: `2.3.0` => `2.4.0`
