### PR TITLE
extras v0.55.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,12 +34,6 @@ inThisBuild(
     scalaVersion := scalaVersion.value,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
-    scalacOptions += (
-      if (scalaVersion.value.startsWith("3."))
-        "-Xsemanticdb"
-      else
-        "-Yrangepos"
-    ),
   )
 )
 
@@ -700,6 +694,12 @@ def crossSubProject(projectName: String, crossProject: CrossProject.Builder): Cr
         else
           scalacOptions.value
       },
+      scalacOptions += (
+        if (scalaVersion.value.startsWith("3."))
+          "-Xsemanticdb"
+        else
+          "-Yrangepos"
+        ),
     )
 }
 

--- a/changelogs/0.55.0.md
+++ b/changelogs/0.55.0.md
@@ -1,0 +1,7 @@
+## [0.55.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am58) - 2026-07-01
+
+## Internal Housekeeping
+
+* [`extras-doobie-tools-ce3`][`extras-doobie-newtype-ce3`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#633)
+
+  This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,8 @@ scalaVersion := "2.12.18"
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.2.0")
+
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.3")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.6")


### PR DESCRIPTION
# extras v0.55.0
## [0.55.0](https://github.com/kevin-lee/extras/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am58) - 2026-07-01

## Internal Housekeeping

* [`extras-doobie-tools-ce3`][`extras-doobie-newtype-ce3`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#633)

  This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).
